### PR TITLE
feat: add discrete Tomcat 9.0.98 persona mimicking CVE-2025-24813

### DIFF
--- a/Yashwin-Tomcat-Honeypot/Dockerfile
+++ b/Yashwin-Tomcat-Honeypot/Dockerfile
@@ -1,0 +1,18 @@
+# Use Tomcat 9.0.98, the exact version affected by CVE-2025-24813
+FROM tomcat:9.0.98
+
+# Add metadata labels for the honeypot orchestration
+LABEL maintainer="Yashwin"
+LABEL persona="apache-tomcat-9.0.98-cve-2025-24813"
+LABEL description="Discrete Tomcat persona mimicking CVE-2025-24813 (Partial PUT RCE)"
+
+# MAKE IT VULNERABLE (The Lure)
+# CVE-2025-24813 requires the DefaultServlet to have 'readonly' set to false.
+# We inject this misconfiguration to ensure automated scanners fall for the trap.
+RUN sed -i '/<servlet-name>default<\/servlet-name>/a \        <init-param>\n            <param-name>readonly<\/param-name>\n            <param-value>false<\/param-value>\n        <\/init-param>' /usr/local/tomcat/conf/web.xml
+
+# Expose the standard HTTP port
+EXPOSE 8080
+
+# Start the Tomcat server
+CMD ["catalina.sh", "run"]

--- a/Yashwin-Tomcat-Honeypot/README.md
+++ b/Yashwin-Tomcat-Honeypot/README.md
@@ -1,0 +1,13 @@
+# Tomcat 9.0.98 Persona (CVE-2025-24813)
+
+This is a discrete Docker container designed to act as a honeypot persona for Apache Tomcat.
+
+## The Lure
+This container specifically mimics **Tomcat 9.0.98**. The `DefaultServlet` in the `web.xml` configuration has been intentionally modified to set `readonly` to `false`. 
+
+This misconfiguration allows "partial PUT" requests, serving as a high-value lure for automated scanners and attackers hunting for the **CVE-2025-24813** Remote Code Execution vulnerability.
+
+## Usage
+To spin up this standalone persona:
+```bash
+docker compose up -d --build

--- a/Yashwin-Tomcat-Honeypot/docker-compose.yml
+++ b/Yashwin-Tomcat-Honeypot/docker-compose.yml
@@ -1,0 +1,9 @@
+
+
+services:
+  tomcat_persona:
+    build: .
+    container_name: yashwin_tomcat_cve_2025_24813
+    ports:
+      - "8080:8080"
+    restart: unless-stopped


### PR DESCRIPTION
Hi @adrianwinckles ,

As discussed in the Slack channel regarding the GSoC 2026 idea to "Develop different personas," I have started putting together a discrete Docker container for an Apache Tomcat persona. 

Following the strategy to use a specific, highly vulnerable version as a lure, this container specifically targets the fingerprint of **Tomcat 9.0.98**. I have intentionally misconfigured the `DefaultServlet` in `web.xml` (setting `readonly` to `false`) to allow partial PUT requests. This serves as a realistic trap for automated scanners hunting for the **CVE-2025-24813** RCE vulnerability.

Currently, this is a standalone container setup. I am opening this as a **Draft** to ensure this file structure and Docker setup aligns with the project's expectations before I look into integrating it further with the rotation mechanism. 

Looking forward to any feedback!