### PR TITLE
fix: replace bare exit with sys.exit(1) and add MISP_KEY validation in misp-push.py

### DIFF
--- a/honeytraps/waf_elk/misp-push/misp-push.py
+++ b/honeytraps/waf_elk/misp-push/misp-push.py
@@ -222,9 +222,13 @@ if __name__ == "__main__":
     MISP_KEY = os.getenv("MISP_KEY", None)
     MISP_VERIFYCERT = True if (os.getenv("MISP_VERIFYCERT", None) == "true") else False
 
-    if (MISP_URL is None):
-        log.critical("MISP_URL was not set in env file, exiting")
-        exit
+    if MISP_URL is None:
+        log.critical("URL_MISP was not set in environment, exiting")
+        sys.exit(1)
+
+    if MISP_KEY is None:
+        log.critical("MISP_KEY was not set in environment, exiting")
+        sys.exit(1)
 
     watcher = Watcher()
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
## Description
Closes #32 

Two bugs fixed in `honeytraps/waf_elk/misp-push/misp-push.py` lines 225–231.

## Bug 1 `exit` without parentheses (line 227)
`exit` alone is a bare reference in Python, not a function call it does nothing. The script logged "exiting" but continued running into `Watcher()`, crashing later with a confusing `ConnectionRefusedError` instead of a clear startup error.

## Bug 2 `MISP_KEY` never validated (new check added)
`MISP_KEY` was read from env but never checked for `None`. If unset Python converts it to the string `"None"` and sends `Authorization: None` as an HTTP header to MISP silent wrong authentication with no useful error message.

## Fix
## Before
```python
if (MISP_URL is None):
    log.critical("MISP_URL was not set in env file, exiting")
    exit  
```
## After
```python
if MISP_URL is None:
    log.critical("URL_MISP was not set in environment, exiting")
    sys.exit(1)

if MISP_KEY is None:
    log.critical("MISP_KEY was not set in environment, exiting")
    sys.exit(1)