### PR TITLE
Fix/modsec entry shebang

### DIFF
--- a/honeytraps/waf_elk/misp-push/misp-push.py
+++ b/honeytraps/waf_elk/misp-push/misp-push.py
@@ -222,9 +222,13 @@ if __name__ == "__main__":
     MISP_KEY = os.getenv("MISP_KEY", None)
     MISP_VERIFYCERT = True if (os.getenv("MISP_VERIFYCERT", None) == "true") else False
 
-    if (MISP_URL is None):
-        log.critical("MISP_URL was not set in env file, exiting")
-        exit
+    if MISP_URL is None:
+        log.critical("URL_MISP was not set in environment, exiting")
+        sys.exit(1)
+
+    if MISP_KEY is None:
+        log.critical("MISP_KEY was not set in environment, exiting")
+        sys.exit(1)
 
     watcher = Watcher()
     loop = asyncio.get_event_loop()

--- a/honeytraps/waf_modsec/modsec_entry.sh
+++ b/honeytraps/waf_modsec/modsec_entry.sh
@@ -1,4 +1,4 @@
-# ~/bin/sh
+#!/bin/sh
 apachectl
 python3 /app/preprocess-modsec-log.py &
 filebeat -e -c filebeat.yml -d "publish"


### PR DESCRIPTION
## Description
Closes #34 

Fixed a broken shebang on line 1 of `honeytraps/waf_modsec/modsec_entry.sh`.

## Change

## Before
```sh
# ~/bin/sh   ← just a comment, not a shebang
```

## After
```sh
#!/bin/sh    ← correct shebang
```

## Why this matters
This script is the Docker container's entry point (CMD ["/modsec_entry.sh"]
in the Dockerfile). It starts all three core honeypot services:
apachectl - Apache WAF
preprocess-modsec-log.py - ModSecurity log processor
filebeat - log shipper to ELK
Without #!, the OS ignores the interpreter directive and falls back to whatever shell is running the process. Inside Docker containers this is unpredictable and can cause services to fail silently on startup.