### PR TITLE
Docs: scaffold plan for optional OWASP CRS auto-update

### DIFF
--- a/honeytraps/waf_modsec/scripts/README.md
+++ b/honeytraps/waf_modsec/scripts/README.md
@@ -1,0 +1,33 @@
+CRS Auto Update (Planned)
+This directory is intended for a small, optional script that will keep our WAF's container up to date on the OWASP ModSecurity Core Rule Set. The design here is one of minimal surprise: unless explicitly configured, you stick with the CRS in the image. Opt-in updates.
+Approach 
+
+Default pinned: If auto-update isn't enabled, there is no auto-update.
+Opt-in updates: when enabled, we install into the existing, expected path within the container (the CRS directory).
+Fail open: if update fails, use existing.
+No path changes: Apache/ModSecurity include references will continue to be the same relative locations of crs-setup.conf and rules/*.conf.
+
+Future configuration 
+
+CRS_UPDATE - turn the updater on/off (default: false)
+CRS_VERSION - the tag/commit/version of CRS to install (default: version pinned in the image)
+Optional: HTTPPROXY, HTTPSPROXY, NO_PROXY - For restricted network access.
+
+Assumptions 
+
+CRS must be accessible at the existing, expected path as referenced in include.conf.
+The updater must be idempotent and leave the crs-dir either completely in-tact or completely in the new version.
+Only runs during container startup (no internal scheduler).
+
+PR Plan 
+
+PR1: Scaffold + Documentation (this file)
+PR2: Implement Updater Logic
+PR3: Dockerfile Changes (Add dependency + the script)
+PR4: Entrypoint Wiring + Runtime Toggles + Basic Logging
+
+
+No Dockerfile/entrypoint/ModSecurity behavior changes have occurred yet.
+
+Quick check
+If you like this plan and approach (small, non-breaking PRs, build toward a functional end), please approve .


### PR DESCRIPTION
Hi @adrianwinckles 


I've just started working with this repository and I went through the GSoC OWASP ideas file to find some potential projects to contribute to. I would be very interested in working on the project idea: "Auto-update OWASP Core Rule Set (CRS) in the Docker-based ModSecurity/Coraza WAF honeypot."

This PR:
  Documents the proposed CSR auto-update feature.
   Lays out a review-friendly PR plan

My proposal for building this:

Leave current behavior unchanged if nothing changes (by default the container continues using CRS bundled within the image unless updates are explicitly turned on).
If updates are enabled (CRSUPDATE=true) then run a small updater at container startup which instead of pulling "latest" pulls the exact pinned CRS version(CRSVERSION=...) that the user desires.
The updater will download and sanity check CRS to a temporary folder first then switch into place atomically, so the ruleset does not exist in half-installed state at any point.
Existing ModSec include paths are not altered by keeping installed CRS the same folder/file layout.
If it should fail, it simply logs the error, falls back to bundled CRS, and the container continues to start as normal.

Next steps:
 The script's actual implementation .
 

Confirmations:
Is it okay to continue working on this project with this approach, starting with small PRs .
Thank you in advance!