### PR TITLE
fix: correct variable syntax and add missing set -e in setup_misp.sh

### DIFF
--- a/honeytraps/misp/setup_misp.sh
+++ b/honeytraps/misp/setup_misp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 source './env' #Importing variables from env file
-set -u
-if [[ -z {$DOCKER_ROOT} ]]; then
+set -eu
+if [[ -z ${DOCKER_ROOT} ]]; then
     echo "DOCKER_ROOT is not set in the env file! exiting"
     exit 1
 fi

--- a/honeytraps/waf_elk/misp-push/misp-push.py
+++ b/honeytraps/waf_elk/misp-push/misp-push.py
@@ -222,9 +222,13 @@ if __name__ == "__main__":
     MISP_KEY = os.getenv("MISP_KEY", None)
     MISP_VERIFYCERT = True if (os.getenv("MISP_VERIFYCERT", None) == "true") else False
 
-    if (MISP_URL is None):
-        log.critical("MISP_URL was not set in env file, exiting")
-        exit
+    if MISP_URL is None:
+        log.critical("URL_MISP was not set in environment, exiting")
+        sys.exit(1)
+
+    if MISP_KEY is None:
+        log.critical("MISP_KEY was not set in environment, exiting")
+        sys.exit(1)
 
     watcher = Watcher()
     loop = asyncio.get_event_loop()

--- a/honeytraps/waf_modsec/modsec_entry.sh
+++ b/honeytraps/waf_modsec/modsec_entry.sh
@@ -1,4 +1,4 @@
-# ~/bin/sh
+#!/bin/sh
 apachectl
 python3 /app/preprocess-modsec-log.py &
 filebeat -e -c filebeat.yml -d "publish"


### PR DESCRIPTION
## Description
Closes #39 

Two fixes in `honeytraps/misp/setup_misp.sh`:

1. `{$DOCKER_ROOT}` → `${DOCKER_ROOT}` , broken brace syntax made the
   DOCKER_ROOT guard never trigger
2. `set -u` → `set -eu`, added `e` flag so failed docker commands
   stop the script instead of silently continuing

Before this fix, the DOCKER_ROOT guard never triggered due to wrong brace syntax `{$DOCKER_ROOT}`, causing the script to silently run chown and mkdir with broken paths. Additionally, missing `set -e` meant a failed `docker pull` would not stop the script it would continue and crash later with a confusing unrelated error. After this fix, any misconfiguration is caught immediately at startup with a clear error message.