### PR TITLE
fix: resolve pipenv dependency installation failure and stale apt index in Dockerfiles

### DIFF
--- a/honeytraps/waf_elk/misp-push/Dockerfile
+++ b/honeytraps/waf_elk/misp-push/Dockerfile
@@ -5,6 +5,6 @@ ENV LC_ALL="C.UTF-8"
 RUN apt-get update
 RUN apt-get install -y nano python3-pip
 RUN pip3 install pipenv
+COPY ./. /app
 RUN pipenv install
-COPY ./ /app
 CMD ["/bin/bash", "/app/start.sh"]

--- a/mds_elk/waf_modsec/Dockerfile
+++ b/mds_elk/waf_modsec/Dockerfile
@@ -1,5 +1,5 @@
 FROM owasp/modsecurity-crs
-RUN apt install -y wget nano curl
+RUN apt-get update && apt-get install -y wget nano curl
 RUN wget https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.2.0-amd64.deb
 RUN dpkg -i filebeat-7.2.0-amd64.deb
 COPY filebeat.yml /etc/filebeat/filebeat.yml


### PR DESCRIPTION
Closes issue: #47 

## Reviewers 
@adrianwinckles 
## What this PR fixes

- Moves `COPY ./ /app` before `RUN pipenv install` so the `Pipfile` is present when dependencies are installed.
- Adds `apt-get update &&` before `apt-get install` so the package index is fresh before installing packages.