### PR TITLE
Fix docker-compose.yml to support Docker Compose v2 by adding service…

### DIFF
--- a/mds_elk/docker-compose.yml
+++ b/mds_elk/docker-compose.yml
@@ -1,27 +1,28 @@
-elk:
-  ports:
-    - "5601:5601"
-    - "9200:9200"
-    - "5044:5044"
-  volumes:
-    - .:/app
-  environment:
-  - LOGSTASH_START=0 
-  build: ./waf_elk/
-  container_name: elk_app
-    
-modsec_crs:
-  ports:
-    - "9091:80"
-    - "8000:8000"
-    - "8080:8080"
-    - "8888:8888"
-  environment:
-    - PARANOIA=5
-  volumes:
-    - .:/app
-  links:
-     - elk
-  build: ./waf_modsec/
-  container_name: modsec_app
-  privileged: true
+services:
+  elk:
+    ports:
+      - "5601:5601"
+      - "9200:9200"
+      - "5044:5044"
+    volumes:
+      - .:/app
+    environment:
+      - LOGSTASH_START=0 
+    build: ./waf_elk/
+    container_name: elk_app
+      
+  modsec_crs:
+    ports:
+      - "9091:80"
+      - "8000:8000"
+      - "8080:8080"
+      - "8888:8888"
+    environment:
+      - PARANOIA=5
+    volumes:
+      - .:/app
+    links:
+      - elk
+    build: ./waf_modsec/
+    container_name: modsec_app
+    privileged: true


### PR DESCRIPTION
I updated docker-compose.yml to work with Docker Compose v2. The old file used the old format (services at the root level), which caused validation errors like:

text
additional properties 'modsec_crs' not allowed
Now everything is wrapped under services: like Compose expects.

Does it build?
Not completely, but that’s not because of this PR.

The compose file is now valid — you can see that by running docker compose config, which shows a clean structure. However, when you actually try to build (docker compose up --build), it fails because the Dockerfile for modsec_crs uses:

           FROM owasp/modsecurity-crs

That image is no longer available on Docker Hub. The build stops with a not found error.

So the fix I made solves the compose format problem, but there’s a separate issue with the base image. I didn’t touch that because it’s unrelated — I wanted to keep this PR focused on the compose v2 compatibility.

Next pull rqst ? 
The project needs to either:
Find a maintained ModSecurity base image that replaces owasp/modsecurity-crs, or
Adjust the Dockerfile to build from something else (like ubuntu + install ModSecurity).

Happy to help with that in a follow‑up PR if needed.