### PR TITLE
fix: update shebang in create_events.py to python3

### DIFF
--- a/misp-doc/create_events.py
+++ b/misp-doc/create_events.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP


### PR DESCRIPTION
## What

Changed shebang on line 1 of misp-doc/create_events.py from #!/usr/bin/env python to #!/usr/bin/env python3.

## Why

Python 2 has been end of life since January 2020. The script imports PyMISP which dropped Python 2 support in v2.4. Running the script directly with the old shebang executes it under Python 2 and immediately fails with an ImportError since PyMISP is not installed for Python 2.

## before
#!/usr/bin/env python

## after
#!/usr/bin/env python3

## Closes: #66 