### PR TITLE
fix: replace hardcoded private IP with Docker service name in logstash.conf

### DIFF
--- a/misp-doc/create_events.py
+++ b/misp-doc/create_events.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from pymisp import PyMISP

--- a/mlogc_elk/mlogc/logstash.conf
+++ b/mlogc_elk/mlogc/logstash.conf
@@ -6,7 +6,7 @@ file {
 }
 output {
   elasticsearch { 
-  	hosts => ["192.168.136.88:9200"] 
+  	hosts => ["elk:9200"]
   	index => "mlogc-audit-%{+yyyy.MM.dd}"
   }
   stdout { codec => rubydebug }


### PR DESCRIPTION
## What's the problem?

While exploring the mlogc_elk setup, I noticed that mlogc/logstash.conf has a hardcoded private IP address (192.168.136.88:9200) as the Elasticsearch host. This IP belongs to the original developer's local machine and does not exist on anyone else's network. So when any other contributor tries to run the mlogc_elk stack, Logstash silently fails to connect to Elasticsearch and no logs get shipped basically the whole pipeline breaks.

## What I fixed

Replaced the hardcoded IP with elk:9200, which is the actual Docker service name defined in docker-compose.yml. Docker resolves this name correctly inside the container network for everyone.

File: mlogc_elk/mlogc/logstash.conf

Before: hosts => ["192.168.136.88:9200"]
After:  hosts => ["elk:9200"]

## Fixes #70 
