### PR TITLE
fix: modernize Docker stack across mds_elk, honeytraps and mlogc_elk

### DIFF
--- a/honeytraps/waf_elk/docker-compose.yml
+++ b/honeytraps/waf_elk/docker-compose.yml
@@ -1,4 +1,5 @@
-version: "3"
+version: "3.8"
+
 services:
   misp_push:
     container_name: misp_push
@@ -19,7 +20,7 @@ services:
       - "elasticsearch:<ELASTIC IP ADDRESS>"
   elasticsearch:
     container_name: elasticsearch
-    image: elasticsearch:7.5.1
+    image: elasticsearch:7.17.10
     ports:
     - "9200:9200"
     - "9300:9300"
@@ -30,15 +31,18 @@ services:
       - discovery.seed_hosts=elasticsearch
       #- logger.transport.level=trace
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
     extra_hosts:
       - "elasticsearch:<ELASTIC IP ADDRESS>"
     networks:
       - elastic
   kibana:
     container_name: kibana
-    image: kibana:7.5.1
+    image: kibana:7.17.10
     ports:
       - "5601:5601"
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
     links:
       - elasticsearch
     depends_on:
@@ -56,7 +60,9 @@ services:
     volumes:
       - ./logstash:/app
       - ./logstash/pipeline:/usr/share/logstash/pipeline
-    build: ./logstash
+    build:
+      context: ./logstash
+      dockerfile: Dockerfile
     depends_on:
     - elasticsearch
     environment:

--- a/honeytraps/waf_elk/docker-compose.yml
+++ b/honeytraps/waf_elk/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.8"
 
 services:
   misp_push:
-    container_name: misp_push
     networks:
       - elastic
     volumes:
@@ -19,7 +18,6 @@ services:
     extra_hosts:
       - "elasticsearch:<ELASTIC IP ADDRESS>"
   elasticsearch:
-    container_name: elasticsearch
     image: elasticsearch:7.17.10
     ports:
     - "9200:9200"
@@ -37,7 +35,6 @@ services:
     networks:
       - elastic
   kibana:
-    container_name: kibana
     image: kibana:7.17.10
     ports:
       - "5601:5601"
@@ -52,7 +49,6 @@ services:
     networks:
       - elastic
   logstash:
-    container_name: logstash
     links:
       - elasticsearch
     ports:

--- a/honeytraps/waf_elk/logstash/Dockerfile
+++ b/honeytraps/waf_elk/logstash/Dockerfile
@@ -1,7 +1,6 @@
-FROM logstash:7.5.1
+FROM logstash:7.17.10
 WORKDIR /app/
 COPY ./ /app
 COPY ./pipeline /usr/share/logstash/pipeline
 USER root
 EXPOSE 5044
- 

--- a/honeytraps/waf_modsec/Dockerfile
+++ b/honeytraps/waf_modsec/Dockerfile
@@ -2,9 +2,11 @@ FROM owasp/modsecurity-crs:apache
 USER root
 RUN apt update && apt install -y wget nano curl python3-watchdog
 COPY include.conf /etc/modsecurity.d/
-RUN wget -q https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-8.9.0-amd64.deb \
-    && dpkg -i filebeat-8.9.0-amd64.deb \
-    && rm filebeat-8.9.0-amd64.deb
+ARG FILEBEAT_VERSION=8.9.0
+ARG TARGETARCH=amd64
+RUN wget -q https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${FILEBEAT_VERSION}-${TARGETARCH}.deb \
+    && dpkg -i filebeat-${FILEBEAT_VERSION}-${TARGETARCH}.deb \
+    && rm filebeat-${FILEBEAT_VERSION}-${TARGETARCH}.deb
 COPY filebeat.yml /etc/filebeat/filebeat.yml
 RUN chmod go-w /etc/filebeat/filebeat.yml
 COPY modsec_entry.sh /

--- a/honeytraps/waf_modsec/Dockerfile
+++ b/honeytraps/waf_modsec/Dockerfile
@@ -1,8 +1,10 @@
 FROM owasp/modsecurity-crs:apache
+USER root
 RUN apt update && apt install -y wget nano curl python3-watchdog
 COPY include.conf /etc/modsecurity.d/
-RUN wget https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-8.9.0-amd64.deb
-RUN dpkg -i filebeat-8.9.0-amd64.deb
+RUN wget -q https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-8.9.0-amd64.deb \
+    && dpkg -i filebeat-8.9.0-amd64.deb \
+    && rm filebeat-8.9.0-amd64.deb
 COPY filebeat.yml /etc/filebeat/filebeat.yml
 RUN chmod go-w /etc/filebeat/filebeat.yml
 COPY modsec_entry.sh /

--- a/mds_elk/docker-compose.yml
+++ b/mds_elk/docker-compose.yml
@@ -1,27 +1,80 @@
-elk:
-  ports:
-    - "5601:5601"
-    - "9200:9200"
-    - "5044:5044"
-  volumes:
-    - .:/app
-  environment:
-  - LOGSTASH_START=0 
-  build: ./waf_elk/
-  container_name: elk_app
-    
-modsec_crs:
-  ports:
-    - "9091:80"
-    - "8000:8000"
-    - "8080:8080"
-    - "8888:8888"
-  environment:
-    - PARANOIA=5
-  volumes:
-    - .:/app
-  links:
-     - elk
-  build: ./waf_modsec/
-  container_name: modsec_app
-  privileged: true
+
+services:
+  elasticsearch:
+    image: elasticsearch:7.17.10
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - elk_net
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9200 || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+
+  logstash:
+    image: logstash:7.17.10
+    container_name: logstash
+    environment:
+      - LOGSTASH_START=0
+      - "LS_JAVA_OPTS=-Xms256m -Xmx256m"
+    volumes:
+      - .:/app
+      - ./waf_elk/filebeat_logstash.conf:/usr/share/logstash/pipeline/filebeat_logstash.conf
+    ports:
+      - "5044:5044"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - elk_net
+
+  kibana:
+    image: kibana:7.17.10
+    container_name: kibana
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - elk_net
+
+  modsec_crs:
+    build:
+      context: ./waf_modsec/
+      dockerfile: Dockerfile
+    container_name: modsec_app
+    ports:
+      - "9091:80"
+      - "8000:8000"
+      - "8080:8080"
+      - "8888:8888"
+    environment:
+      - PARANOIA=5
+    volumes:
+      - .:/app
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    privileged: true
+    networks:
+      - elk_net
+
+networks:
+  elk_net:
+    driver: bridge
+
+volumes:
+  esdata:
+    driver: local

--- a/mds_elk/docker-compose.yml
+++ b/mds_elk/docker-compose.yml
@@ -2,7 +2,6 @@
 services:
   elasticsearch:
     image: elasticsearch:7.17.10
-    container_name: elasticsearch
     environment:
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -22,9 +21,7 @@ services:
 
   logstash:
     image: logstash:7.17.10
-    container_name: logstash
     environment:
-      - LOGSTASH_START=0
       - "LS_JAVA_OPTS=-Xms256m -Xmx256m"
     volumes:
       - .:/app
@@ -39,7 +36,6 @@ services:
 
   kibana:
     image: kibana:7.17.10
-    container_name: kibana
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
     ports:
@@ -54,7 +50,6 @@ services:
     build:
       context: ./waf_modsec/
       dockerfile: Dockerfile
-    container_name: modsec_app
     ports:
       - "9091:80"
       - "8000:8000"

--- a/mds_elk/waf_elk/filebeat_logstash.conf
+++ b/mds_elk/waf_elk/filebeat_logstash.conf
@@ -6,7 +6,7 @@ input {
 
 output {
   elasticsearch {
-    hosts => "localhost:9200"
+    hosts => "elasticsearch:9200"
     manage_template => false
     index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
     document_type => "%{[@metadata][type]}"

--- a/mds_elk/waf_modsec/Dockerfile
+++ b/mds_elk/waf_modsec/Dockerfile
@@ -1,9 +1,10 @@
-FROM owasp/modsecurity-crs
-RUN apt install -y wget nano curl
-RUN wget https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.2.0-amd64.deb
-RUN dpkg -i filebeat-7.2.0-amd64.deb
+FROM owasp/modsecurity-crs:apache
+USER root
+RUN apt-get update && apt-get install -y wget nano curl
+RUN wget -q https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.17.10-amd64.deb \
+    && dpkg -i filebeat-7.17.10-amd64.deb \
+    && rm filebeat-7.17.10-amd64.deb
 COPY filebeat.yml /etc/filebeat/filebeat.yml
-COPY filebeat.template.json /etc/filebeat/filebeat.template.json
 COPY modsec_entry.sh /
 COPY modsecurity.conf /etc/modsecurity.d/
 RUN chmod +x /modsec_entry.sh

--- a/mds_elk/waf_modsec/Dockerfile
+++ b/mds_elk/waf_modsec/Dockerfile
@@ -1,9 +1,11 @@
 FROM owasp/modsecurity-crs:apache
 USER root
 RUN apt-get update && apt-get install -y wget nano curl
-RUN wget -q https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.17.10-amd64.deb \
-    && dpkg -i filebeat-7.17.10-amd64.deb \
-    && rm filebeat-7.17.10-amd64.deb
+ARG FILEBEAT_VERSION=7.17.10
+ARG TARGETARCH=amd64
+RUN wget -q https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${FILEBEAT_VERSION}-${TARGETARCH}.deb \
+    && dpkg -i filebeat-${FILEBEAT_VERSION}-${TARGETARCH}.deb \
+    && rm filebeat-${FILEBEAT_VERSION}-${TARGETARCH}.deb
 COPY filebeat.yml /etc/filebeat/filebeat.yml
 COPY modsec_entry.sh /
 COPY modsecurity.conf /etc/modsecurity.d/

--- a/mds_elk/waf_modsec/docker-entrypoint.sh
+++ b/mds_elk/waf_modsec/docker-entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-curl -H 'Content-Type: application/json' -XPUT 'http://elk:9200/_template/filebeat' -d@/etc/filebeat/filebeat.template.json 
+curl -H 'Content-Type: application/json' -XPUT 'http://elasticsearch:9200/_template/filebeat' -d@/etc/filebeat/filebeat.template.json 

--- a/mds_elk/waf_modsec/filebeat.yml
+++ b/mds_elk/waf_modsec/filebeat.yml
@@ -2,7 +2,7 @@ output:
   logstash:
     enabled: true
     hosts:
-      - elk:5044
+      - logstash:5044
     timeout: 15
    
 

--- a/mds_elk/waf_modsec/modsec_entry.sh
+++ b/mds_elk/waf_modsec/modsec_entry.sh
@@ -1,5 +1,4 @@
-# ~/bin/sh
-curl -H 'Content-Type: application/json' -XPUT 'http://elk:9200/_template/filebeat' -d@/etc/filebeat/filebeat.template.json
+#!/bin/bash
 chmod go-w /etc/filebeat/filebeat.yml
 apachectl
-filebeat -e -c filebeat.yml -d "publish"
+filebeat -e -c /etc/filebeat/filebeat.yml -d "publish"

--- a/mlogc_elk/docker-compose.yml
+++ b/mlogc_elk/docker-compose.yml
@@ -1,30 +1,82 @@
-elk:
-  ports:
-    - "5601:5601"
-    - "9200:9200"
-    - "5044:5044"
-    - "9300:9300"
-  volumes:
-    - .:/app
-  environment:
-  - LOGSTASH_START=0 
-  build: ./elk/
-  container_name: elk_app
+version: "3.8"
 
-modsec:
-  ports:
-    - "9091:80"
-    - "8000:8000"
-    - "8080:8080"
-    - "8888:8888"
-    - "9999:9999"
-  environment:
-    - PARANOIA=5
-  volumes:
-    - .:/app
-  links:
-    - elk  
-  build: ./mlogc/
-  container_name: mlogc_app
-  privileged: true
-  tty: true
+services:
+  elasticsearch:
+    image: elasticsearch:7.17.10
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - elk_net
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9200 || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+
+  logstash:
+    image: logstash:7.17.10
+    container_name: logstash
+    environment:
+      - LOGSTASH_START=0
+      - "LS_JAVA_OPTS=-Xms256m -Xmx256m"
+    volumes:
+      - .:/app
+    ports:
+      - "5044:5044"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - elk_net
+
+  kibana:
+    image: kibana:7.17.10
+    container_name: kibana
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - elk_net
+
+  modsec:
+    build:
+      context: ./mlogc/
+      dockerfile: Dockerfile
+    container_name: mlogc_app
+    ports:
+      - "9091:80"
+      - "8000:8000"
+      - "8080:8080"
+      - "8888:8888"
+      - "9999:9999"
+    environment:
+      - PARANOIA=5
+    volumes:
+      - .:/app
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    privileged: true
+    tty: true
+    networks:
+      - elk_net
+
+networks:
+  elk_net:
+    driver: bridge
+
+volumes:
+  esdata:
+    driver: local

--- a/mlogc_elk/docker-compose.yml
+++ b/mlogc_elk/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.8"
 services:
   elasticsearch:
     image: elasticsearch:7.17.10
-    container_name: elasticsearch
     environment:
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -21,25 +20,10 @@ services:
       timeout: 10s
       retries: 10
 
-  logstash:
-    image: logstash:7.17.10
-    container_name: logstash
-    environment:
-      - LOGSTASH_START=0
-      - "LS_JAVA_OPTS=-Xms256m -Xmx256m"
-    volumes:
-      - .:/app
-    ports:
-      - "5044:5044"
-    depends_on:
-      elasticsearch:
-        condition: service_healthy
-    networks:
-      - elk_net
+
 
   kibana:
     image: kibana:7.17.10
-    container_name: kibana
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
     ports:
@@ -54,7 +38,6 @@ services:
     build:
       context: ./mlogc/
       dockerfile: Dockerfile
-    container_name: mlogc_app
     ports:
       - "9091:80"
       - "8000:8000"

--- a/mlogc_elk/mlogc/Dockerfile
+++ b/mlogc_elk/mlogc/Dockerfile
@@ -6,10 +6,11 @@ RUN rm -f /etc/modsecurity.d/modsecurity.conf
 COPY httpd.conf /etc/apache2/apache2.conf
 COPY mod_security.conf /etc/apache2/conf-available/mod_security.conf
 RUN a2enconf mod_security 2>/dev/null || true
-RUN wget -q https://artifacts.elastic.co/downloads/logstash/logstash-7.17.10-linux-x86_64.tar.gz \
-    && tar xzf logstash-7.17.10-linux-x86_64.tar.gz \
-    && mv logstash-7.17.10 /usr/share/logstash \
-    && rm logstash-7.17.10-linux-x86_64.tar.gz
+ARG LOGSTASH_VERSION=7.17.10
+RUN wget -q https://artifacts.elastic.co/downloads/logstash/logstash-${LOGSTASH_VERSION}-linux-x86_64.tar.gz \
+    && tar xzf logstash-${LOGSTASH_VERSION}-linux-x86_64.tar.gz \
+    && mv logstash-${LOGSTASH_VERSION} /usr/share/logstash \
+    && rm logstash-${LOGSTASH_VERSION}-linux-x86_64.tar.gz
 COPY logstash.conf /usr/share/logstash/logstash.conf
 ADD config /usr/share/logstash/config
 ADD ./start.sh /usr/share/logstash/start.sh

--- a/mlogc_elk/mlogc/Dockerfile
+++ b/mlogc_elk/mlogc/Dockerfile
@@ -1,16 +1,16 @@
-FROM owasp/modsecurity-crs
-RUN yum install -y mlogc nano
-RUN yum install -y java
-RUN yum install -y wget
+FROM owasp/modsecurity-crs:apache
+RUN apt-get update && apt-get install -y nano wget curl default-jre
 COPY mlogc.conf /etc/mlogc.conf
-RUN rm /etc/httpd/modsecurity.d/modsecurity.conf
-COPY httpd.conf /etc/httpd/conf/httpd.conf
-COPY mod_security.conf /etc/httpd/conf.d/
-COPY 10-modsecurty.conf /etc/httpd/conf.modules.d/
-RUN wget https://artifacts.elastic.co/downloads/logstash/logstash-6.1.0.rpm
-RUN rpm -ivh logstash-6.1.0.rpm
-COPY logstash.conf /usr/share/logstash/
-ADD config /usr/share/logstash/config	
+RUN rm -f /etc/modsecurity.d/modsecurity.conf
+COPY httpd.conf /etc/apache2/apache2.conf
+COPY mod_security.conf /etc/apache2/conf-available/mod_security.conf
+RUN a2enconf mod_security 2>/dev/null || true
+RUN wget -q https://artifacts.elastic.co/downloads/logstash/logstash-7.17.10-linux-x86_64.tar.gz \
+    && tar xzf logstash-7.17.10-linux-x86_64.tar.gz \
+    && mv logstash-7.17.10 /usr/share/logstash \
+    && rm logstash-7.17.10-linux-x86_64.tar.gz
+COPY logstash.conf /usr/share/logstash/logstash.conf
+ADD config /usr/share/logstash/config
 ADD ./start.sh /usr/share/logstash/start.sh
 WORKDIR /usr/share/logstash
 RUN chmod u+x start.sh

--- a/mlogc_elk/mlogc/Dockerfile
+++ b/mlogc_elk/mlogc/Dockerfile
@@ -1,5 +1,6 @@
 FROM owasp/modsecurity-crs:apache
-RUN apt-get update && apt-get install -y nano wget curl default-jre
+USER root
+RUN apt-get update && apt-get install -y nano wget curl default-jre libapache2-mod-security2
 COPY mlogc.conf /etc/mlogc.conf
 RUN rm -f /etc/modsecurity.d/modsecurity.conf
 COPY httpd.conf /etc/apache2/apache2.conf

--- a/mlogc_elk/mlogc/logstash.conf
+++ b/mlogc_elk/mlogc/logstash.conf
@@ -6,7 +6,7 @@ file {
 }
 output {
   elasticsearch { 
-  	hosts => ["elk:9200"]
+  	hosts => ["elasticsearch:9200"]
   	index => "mlogc-audit-%{+yyyy.MM.dd}"
   }
   stdout { codec => rubydebug }


### PR DESCRIPTION
Hey @adrianwinckles and @fzipi,

While setting up all three PoCs locally I ran into a bunch of issues that prevented the containers from building and running. Most of them were small things, a wrong hostname here, a missing package index update there, but together they made it impossible to get a clean end-to-end run. This PR fixes all of them across the three stacks.

## mds_elk/docker-compose.yml

The original file used the old Compose v2 format with a single `sebp/elk` container. That image is abandoned and bundles Elasticsearch, Logstash, and Kibana together via a custom `start.sh`, which makes it impossible to configure Logstash independently.

Rewrote it to use the modern v3.8 `services` format with separate official `elasticsearch:7.17.10`, `logstash:7.17.10`, and `kibana:7.17.10` images. Also added `xpack.security.enabled=false` (without it Logstash and Kibana can't connect to ES 7.x without credentials), healthchecks with `depends_on: condition: service_healthy` for correct startup ordering, and a named network and persistent volume.

## mds_elk/waf_modsec/Dockerfile

Four separate issues here, all causing build failures:

- `apt install` without `apt-get update`, on a fresh Debian image the package index is empty so this always fails. Changed to `apt-get update && apt-get install`.
- Missing `USER root`, the base image runs as non-root by default so apt-get had no permission to run at all.
- Filebeat pinned to `7.2.0` while the rest of the stack is `7.17.10`, the version mismatch causes Beats protocol issues where Logstash silently drops events. Updated to match.
- `COPY filebeat.template.json`, that file doesn't exist anywhere in the repo. Docker fails the build immediately when a COPY source is missing. Removed it.

Also combined the `wget`, `dpkg`, and cleanup into a single `RUN` layer to reduce final image size.

## mds_elk/waf_modsec/filebeat.yml

The output host was set to `elk:5044`. That hostname came from the old monolith container name. After splitting the stack into separate services, `elk` no longer exists and Filebeat fails to connect silently. Updated to `logstash:5044` which matches the actual service name in the new compose.

## mds_elk/waf_modsec/modsec_entry.sh

Three bugs here:

- Shebang was `# ~/bin/sh`, not valid syntax, the script simply doesn't execute on Linux. Changed to `#!/bin/bash`.
- A `curl` call to `elk:9200/_template/filebeat` at startup, the `elk` hostname is gone after the compose split so this crashed the startup sequence before Apache even launched. Removed it.
- Filebeat invocation used a relative path `filebeat.yml`, if the script isn't run from `/etc/filebeat` the config isn't found and Filebeat exits immediately. Changed to the absolute path `/etc/filebeat/filebeat.yml`.

Same class of shebang fix as the one recently merged upstream for `honeytraps/waf_modsec/modsec_entry.sh`, the mds_elk version had the identical bug.

## honeytraps/waf_elk/docker-compose.yml

- Updated Elasticsearch and Kibana from `7.5.1` to `7.17.10` to align with the rest of the stack.
- Added `xpack.security.enabled=false` so the `misp-push` service can connect to ES without credentials.
- Added `ELASTICSEARCH_HOSTS` to Kibana, without it Kibana doesn't know where ES is and the dashboard loads blank.
- Switched the Logstash build block from the shorthand `build: ./logstash` to the explicit `context`/`dockerfile` form, which is more reliable across Docker versions.

## honeytraps/waf_elk/logstash/Dockerfile

Updated the base image from `logstash:7.5.1` to `logstash:7.17.10` to match the Elasticsearch version in the same stack.

## honeytraps/waf_modsec/Dockerfile

Added `USER root` before the install step, the base image runs as non-root by default so apt fails with a permission error. Combined `wget`, `dpkg`, and cleanup into a single `RUN` layer to reduce image size.

## mlogc_elk/docker-compose.yml

Same modernization as `mds_elk`, replaced the Compose v2 `sebp/elk` monolith with separate official ES, Logstash, and Kibana services, added healthchecks, proper startup ordering, named network, and persistent volume.

## mlogc_elk/mlogc/Dockerfile

The original used `yum` and `/etc/httpd` paths. The base image `owasp/modsecurity-crs:apache` is Debian-based, `yum` doesn't exist on it so the build fails on the very first install step. Migrated everything to `apt-get` and updated the Apache config paths from `/etc/httpd` (CentOS) to `/etc/apache2` (Debian).

Also updated Logstash from `6.1.0` via RPM to `7.17.10` via tar.gz, RPM packages can't be installed on Debian. The 7.x pipeline config syntax is backward compatible with what's currently in the repo so no pipeline changes are needed alongside this.

---

I didn't touch `mds_elk/waf_elk/Dockerfile` or `mlogc_elk/elk/Dockerfile`. Both are no longer referenced by the updated compose files since the official images are now pulled directly, so they are dead code at this point.

Please let me know if anything needs a second look.