### PR TITLE
fix: replace Flask dev server with Gunicorn in Stimulus Engine

### DIFF
--- a/CHAMELEON-REN/layer1_controller/engine/Dockerfile
+++ b/CHAMELEON-REN/layer1_controller/engine/Dockerfile
@@ -12,4 +12,4 @@ COPY stimulus_engine.py .
 EXPOSE 5000
 
 # Start the Stimulus Engine
-CMD ["python", "stimulus_engine.py"]
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "stimulus_engine:app"]

--- a/CHAMELEON-REN/layer1_controller/engine/requirements.txt
+++ b/CHAMELEON-REN/layer1_controller/engine/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.0
 requests==2.31.0
 redis==5.0.1
+gunicorn==21.2.0


### PR DESCRIPTION
# Pull Request: Fix DoS Risk by replacing Flask Dev Server with Gunicorn in Stimulus Engine

FIxes #80

## 📝 What does this PR do?

This Pull Request addresses a critical performance and reliability bottleneck in the `CHAMELEON-REN` Stimulus Engine. 

Previously, the honeypot's core routing engine was running using Flask's built-in development server. As the Stimulus Engine sits at Layer 1 and is designed to handle potentially high volumes of malicious traffic, port scans, and payloads, using the single-threaded development server introduced a severe Denial of Service (DoS) risk. Attackers could easily exhaust the server resources or hang connections, blinding the entire honeypot network.

This PR wraps the Flask application in **Gunicorn**, a production-ready WSGI HTTP server, which manages multiple worker processes to safely handle concurrent requests and maintain high availability under pressure.

## 🛠️ Proposed Changes (Implementation Plan)

When we are ready to proceed, I will make the following specific code changes:

### 1. Update `CHAMELEON-REN/layer1_controller/engine/requirements.txt`
I will add `gunicorn==21.2.0` to the list of Python dependencies so it is installed when the Docker image is built.
```diff
 Flask==3.0.0
 requests==2.31.0
 redis==5.0.1
+gunicorn==21.2.0
```

### 2. Update `CHAMELEON-REN/layer1_controller/engine/Dockerfile`
I will update the `CMD` instruction to start the engine using `gunicorn` with 4 worker processes instead of running `python stimulus_engine.py`.
```diff
 # Start the Stimulus Engine
-CMD ["python", "stimulus_engine.py"]
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "stimulus_engine:app"]
```

## 🔒 Safety and Verification
- This change doesn't modify the logic of `stimulus_engine.py` (which handles the routing), it only changes *how* the application is served.
- Since we use 4 workers (`-w 4`), the honeypot will instantly be able to process multiple concurrent malicious requests simultaneously without locking up.

---

