### PR TITLE
fix: repair log pipeline in honeytraps/waf_modsec : Apache foreground + Filebeat JSON parsing

### DIFF
--- a/honeytraps/waf_modsec/filebeat.yml
+++ b/honeytraps/waf_modsec/filebeat.yml
@@ -9,3 +9,5 @@ filebeat:
     - type: log
       paths:
         - /var/log/modsec_audit.log
+      json.keys_under_root: true
+      json.add_error_key: true

--- a/honeytraps/waf_modsec/modsec_entry.sh
+++ b/honeytraps/waf_modsec/modsec_entry.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-apachectl
-filebeat -e -c /etc/filebeat/filebeat.yml -d "publish"
+filebeat -e -c /etc/filebeat/filebeat.yml &
+apachectl -DFOREGROUND


### PR DESCRIPTION
# fix: repair broken log pipeline in honeytraps/waf_modsec : ensure attack events reach Elasticsearch

**Fixes #85**

---

## Summary

After the v1.1 schema migration (PR #76), the `honeytraps/waf_modsec` log pipeline was left in a
partially broken state. ModSecurity correctly writes JSON audit logs, but **Filebeat never parses
them as JSON** and **Apache runs without a foreground supervisor**, meaning any Apache crash silently
kills all logging while the container appears healthy. This PR completes the pipeline cleanup so
that attack events reliably reach Elasticsearch (and subsequently MISP).

---

## What is broken in `upstream/master` right now

### Problem 1 : `modsec_entry.sh`: Apache has no supervisor

```sh
# Current upstream/master
#!/bin/sh
apachectl                                                  # ← daemonizes and exits
filebeat -e -c /etc/filebeat/filebeat.yml -d "publish"    # ← becomes PID 1 in Docker
```

`apachectl` without `-DFOREGROUND` forks Apache to the background and returns immediately.
Docker keeps the container alive only because `filebeat` is in the foreground. If Apache
crashes (OOM, bad config, signal), the container **continues running silently with no web
server** — and keeps shipping an empty log file to Elasticsearch. There is no health check
and no restart mechanism for Apache.

The fix is to run `filebeat` in the **background** and give `apachectl -DFOREGROUND` PID 1,
so Docker's own lifecycle is tied to Apache. This mirrors exactly how the official
`owasp/modsecurity-crs:apache` base image is intended to be used.

### Problem 2 : `filebeat.yml`: JSON parsing is missing

```yaml
# Current upstream/master
filebeat:
  inputs:
    - type: log
      paths:
        - /var/log/modsec_audit.log
      # ← No json.* options!
```

Since PR #76 added `SecAuditLogFormat JSON` to ModSecurity's config, every line in
`modsec_audit.log` is a complete JSON object. Without `json.keys_under_root: true`, Filebeat
ships the raw JSON **as a plain string** inside a `message` field. Elasticsearch receives
unstructured text blobs instead of structured, queryable documents. Kibana dashboards,
Logstash filters, and MISP field-mapping all fail silently.

---

## Changes in this PR

### `honeytraps/waf_modsec/modsec_entry.sh`

```diff
 #!/bin/sh
-apachectl
-filebeat -e -c /etc/filebeat/filebeat.yml -d "publish"
+filebeat -e -c /etc/filebeat/filebeat.yml &
+apachectl -DFOREGROUND
```

- `filebeat` moves to the **background**.
- `apachectl -DFOREGROUND` becomes the foreground process (PID 1), so Docker correctly
  restarts or stops the container when Apache exits.

### `honeytraps/waf_modsec/filebeat.yml`

```diff
 filebeat:
   inputs:
     - type: log
       paths:
         - /var/log/modsec_audit.log
+      json.keys_under_root: true
+      json.add_error_key: true
```

- `json.keys_under_root: true` : extracts all JSON fields from each log line to the top level
  of the Elasticsearch document, making every ModSecurity field (`transaction.remote_address`,
  `request.request_line`, etc.) directly queryable.
- `json.add_error_key: true` : if a log line is malformed, Filebeat adds an `error.message`
  field instead of silently dropping the event.

---

## Files Changed

| File | Change |
|---|---|
| `honeytraps/waf_modsec/modsec_entry.sh` | Run Filebeat in background; Apache foreground (PID 1) |
| `honeytraps/waf_modsec/filebeat.yml` | Add JSON parsing options so events are structured in ES |

---

## Testing

1. Build the image from the updated files:
   ```sh
   docker compose -f honeytraps/waf_modsec/docker-compose.yml build
   docker compose -f honeytraps/waf_modsec/docker-compose.yml up -d
   ```

2. Send a test attack:
   ```sh
   curl "http://localhost:9091/?q=<script>alert(1)</script>"
   ```

3. Verify the event appears as a **structured JSON document** in Elasticsearch:
   ```sh
   curl -s http://localhost:9200/filebeat-*/_search?pretty | jq '.hits.hits[0]._source | keys'
   # Expected: ["@timestamp", "request", "response", "transaction", ...]
   # Before fix: ["@timestamp", "message", ...]   ← raw string, not parsed
   ```

4. Verify Apache is PID 1 inside the container:
   ```sh
   docker exec modsec_app ps aux | head -5
   # Expected: PID 1 is httpd/apache2
   ```

---

## Why only these 2 files?

The `preprocess-modsec-log.py` script and `modsec_audit_processed.log` were already removed
from the Dockerfile in PR #76. The orphaned `.py` file still exists in the repository but is
not referenced anywhere in the current image build — a separate cleanup PR can delete it to
avoid confusion. This PR stays focused on the two files that directly cause silent data loss.

---

## Related

- Fixes #85 - `[Bug] Silent loss of all attack events: dead log pipeline in honeytraps/waf_modsec`
- Partial cleanup from PR #76 (`feat: v1.1 JSON Schema Migration and Pipeline Enrichment`)
