### PR TITLE
Fix : misp-push event loss and timezone synchronization failures

### DIFF
--- a/honeytraps/waf_elk/misp-push/Pipfile
+++ b/honeytraps/waf_elk/misp-push/Pipfile
@@ -3,13 +3,9 @@ name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
-[dev-packages]
-
 [packages]
 pymisp = "*"
 requests = "*"
 httpx = "*"
-elasticsearch-async = "*"
-elasticsearch = "*"
+elasticsearch = {version="<8.0.0", extras=["async"]}
 aiohttp = "*"
-

--- a/honeytraps/waf_elk/misp-push/misp-push.py
+++ b/honeytraps/waf_elk/misp-push/misp-push.py
@@ -136,17 +136,7 @@ class ElasticConnector():
         pass
 
     async def set_index(self, index: str) -> None:
-        index_name = ""
-        indexes = await self.es.indices.get(index)
-        for index in indexes:
-            log.debug("Index is " + str(index))
-            index_str = str(index) 
-            if index_str.find("honeypot-attacks-") != -1:
-                log.debug("found it!")
-                #log.debug(index_str)
-                index_name = index_str
-                #break
-        self.index = index_name
+        self.index = index
 
     async def wait_until_up(self) -> None:
         while (True):
@@ -159,8 +149,12 @@ class ElasticConnector():
             except Exception as e:
                 await asyncio.sleep(1)
 
-    async def search(self, start: datetime, end: datetime) -> bool:
-        return await self.es.search(index=self.index,body={'query':{'range':{'@timestamp':{'gte':start.isoformat(),'lt':'now'}}}})
+    async def search(self, start: datetime, end: datetime) -> dict:
+        return await self.es.search(
+            index=self.index,
+            size=10000,
+            body={'query':{'range':{'@timestamp':{'gte':start.isoformat(),'lt':end.isoformat()}}}}
+        )
 
 class Watcher():
     '''Watching for new events in elasticsearch'''
@@ -170,7 +164,7 @@ class Watcher():
     misp = None
 
     def __init__(self):
-        self.lastSearched = datetime.now() - timedelta(seconds=10)
+        self.lastSearched = datetime.now(timezone.utc) - timedelta(seconds=10)
 
     async def run(self):
         self.elastic = ElasticConnector()
@@ -179,10 +173,11 @@ class Watcher():
         self.misp = MispConnector(MISP_URL, MISP_KEY)
         while(True):
             try:
-                res = await self.queryElastic()
+                now = datetime.now(timezone.utc)
+                res = await self.queryElastic(now)
                 log.debug('Got %d Hits:' % res['hits']['total']['value'])
                 self.sendEvents(res)
-                self.lastSearched = datetime.now()
+                self.lastSearched = now
             except PyMISPError as e:
                 log.warning("Failed to connect to MISP, error: " + str(e))
             except ConnectTimeoutError as e:
@@ -198,8 +193,8 @@ class Watcher():
             #    log.error("Unknown error: " + str(e))
             await asyncio.sleep(self.WATCH_INTERVAL)
 
-    async def queryElastic(self):
-        return await self.elastic.search(self.lastSearched, datetime.now())   
+    async def queryElastic(self, now: datetime):
+        return await self.elastic.search(self.lastSearched, now)   
 
     def sendEvents(self, results):
         for event in results['hits']['hits']:


### PR DESCRIPTION
# Fix misp-push event loss and timezone synchronization failures

Fixes #88

## What does this PR do?
This PR addresses several critical logic flaws in `misp-push.py` that caused attack logs to be silently dropped or duplicated, depending on the volume of events and the host system's timezone.

### Changes Made:
- **Timezone Synchronization**: Migrated all timestamps to use `datetime.now(timezone.utc)` instead of the naive local `datetime.now()`. This ensures the `.isoformat()` timestamps passed to Elasticsearch are accurately interpreted as UTC, fixing the bug where the query window shifted forward/backward relative to the local offset.
- **Pagination and Data Loss**: explicitly configured the Elasticsearch `size` parameter to `10000` (up from the default of 10 hits). This prevents the pipeline from dropping events if more than 10 attacks arrive within the 10-second polling interval.
- **Polling Window Race Condition**: Refactored the `lastSearched` update logic so that the `now` timestamp used to bound the `lt` condition in the Elasticsearch query is preserved and assigned to `lastSearched`. Previously, updating `lastSearched` after the blocking `sendEvents` step caused any events indexed during that network request to be lost.
- **Index Resolution**: Simplified the `set_index` function to apply the `"honeypot-attacks-*"` wildcard directly in the query. The previous logic looped over all indices and only used the name of the final matching index, effectively ignoring all other indices if daily rolling indices were present.

## How to test
1. Deploy the `misp-push` docker container on a host configured to a non-UTC timezone (e.g., `America/New_York` or `Asia/Kolkata`).
2. Trigger an automated attack burst against the honeypot (using e.g. Nikto or a custom script) generating > 15 logs in a 10-second window.
3. Verify that MISP receives **all** logged events and no logs are skipped.
4. Verify that duplicate events are not ingested.
