### PR TITLE
chore: upgrade base WAF to CRS v4.25 LTS and wire plugin architecture

### DIFF
--- a/honeytraps/waf_modsec/Dockerfile
+++ b/honeytraps/waf_modsec/Dockerfile
@@ -1,4 +1,5 @@
-FROM owasp/modsecurity-crs:apache
+ARG CRS_VERSION=4.25.0-apache-lts
+FROM owasp/modsecurity-crs:${CRS_VERSION}
 USER root
 RUN apt update && apt install -y wget nano curl
 COPY include.conf /etc/modsecurity.d/

--- a/honeytraps/waf_modsec/include.conf
+++ b/honeytraps/waf_modsec/include.conf
@@ -1,3 +1,8 @@
 include "/etc/modsecurity.d/modsecurity.conf"
 include /etc/modsecurity.d/owasp-crs/crs-setup.conf
+# load plugin configs and before-rules before the CRS core rules
+include /etc/modsecurity.d/owasp-crs/plugins/*-config.conf
+include /etc/modsecurity.d/owasp-crs/plugins/*-before.conf
 include /etc/modsecurity.d/owasp-crs/rules/*.conf
+# load plugin after-rules after the CRS core rules
+include /etc/modsecurity.d/owasp-crs/plugins/*-after.conf

--- a/mds_elk/docker-compose.yml
+++ b/mds_elk/docker-compose.yml
@@ -51,9 +51,8 @@ services:
       context: ./waf_modsec/
       dockerfile: Dockerfile
     ports:
-      - "9091:80"
+      - "9091:8080"
       - "8000:8000"
-      - "8080:8080"
       - "8888:8888"
     environment:
       - PARANOIA=5

--- a/mds_elk/waf_modsec/Dockerfile
+++ b/mds_elk/waf_modsec/Dockerfile
@@ -1,4 +1,5 @@
-FROM owasp/modsecurity-crs:apache
+ARG CRS_VERSION=4.25.0-apache-lts
+FROM owasp/modsecurity-crs:${CRS_VERSION}
 USER root
 RUN apt-get update && apt-get install -y wget nano curl
 ARG FILEBEAT_VERSION=7.17.10


### PR DESCRIPTION
This PR handles the core infrastructure upgrades needed before we can start dropping in custom plugins. 

I bumped the CRS base images to the latest 4.x LTS release and wired up the internal config paths so the engine actually knows how to load plugins dynamically.

**Changes:**
- **Base image bump**: Pinned `ARG CRS_VERSION=4.25.0-apache-lts` in both active Dockerfiles (`mds_elk` and `honeytraps`) so the environments stay consistent.
- **Plugin wiring**: Modified `honeytraps/waf_modsec/include.conf` to explicitly include the `plugins/*-config.conf`, `*-before.conf`, and `*-after.conf` pathways required by CRS v4.
- **Port fix**: Consolidated ports in `mds_elk/docker-compose.yml` to map host port 9091 to container port 8080 to fix a local apache bind issue I was hitting.

I booted the stack locally and ran some quick test payloads against it just to make sure the WAF still intercepts traffic correctly on the new version.
