### PR TITLE
feat: implement CRS 4.x active deception plugins, hot-reload watchdog, and v1.1 telemetry schema

### DIFF
--- a/docs/SCHEMA_MIGRATION.md
+++ b/docs/SCHEMA_MIGRATION.md
@@ -26,7 +26,7 @@ documented here.
 | `audit_data.messages[*].severity` | `attack_classification.severity` | Extracted from message array |
 | `audit_data.messages[*].id` | `attack_classification.honeytrap_rule_id` | First rule ID in chain |
 | _(not present)_ | `attack_classification.type` | Derived from CRS rule file path |
-| _(not present)_ | `attack_classification.honeytrap_triggered` | true if rule_id in 999xxx or 9500000-9999999 |
+| _(not present)_ | `attack_classification.honeytrap_triggered` | true if rule_id is in 9500000-9999999 (the honeytrap plugin range) |
 | _(not present)_ | `attack_classification.cve_triggered` | Extracted from `[tag "CVE-..."]` in message |
 | _(not present)_ | `mitre_attack` | Array of technique IDs derived from rule file |
 | _(not present)_ | `geoip2.*` | GeoIP2 City enrichment from remote_address |
@@ -35,6 +35,7 @@ documented here.
 | _(not present)_ | `persona_context.*` | Active honeypot persona from env vars |
 | _(not present)_ | `response.honeytoken_triggered` | true when `Admin=` appears in Set-Cookie |
 | _(not present)_ | `feed_metadata.export_timestamp` | Logstash @timestamp at index time |
+| _(not present)_ | `feed_metadata.batch_id` | At ingestion `"pending_export"`, rewritten later by export daemon |
 
 ---
 
@@ -53,7 +54,7 @@ The following fields are new in v1.1 they don't exist in mlogc output and are ad
 | Field | Type | Description |
 |---|---|---|
 | `event_type` | keyword | `"attack"` or `"persona_rotation"` |
-| `persona_rotation.previous_persona` | keyword | The persona before rotation, or `"none"` for initial deployment |
+| `persona_rotation.previous_persona` | keyword | The persona before rotation, or `null` for initial deployment |
 | `persona_rotation.new_persona` | keyword | The newly activated persona |
 | `persona_rotation.trigger` | keyword | e.g., `"manual"`, `"shodan"`, `"scheduled"` |
 | `persona_rotation.trigger_detail` | text | Explanation of the trigger |
@@ -78,6 +79,7 @@ The following fields are new in v1.1 they don't exist in mlogc output and are ad
 | `geoip2.isp` | keyword | Absent if ASN db missing |
 | `response.honeytoken_triggered` | boolean | |
 | `feed_metadata.export_timestamp` | date | |
+| `feed_metadata.batch_id` | keyword | At ingestion `"pending_export"`, rewritten later by export daemon |
 
 ---
 

--- a/honeytraps/waf_elk/logstash/pipeline/logstash.conf
+++ b/honeytraps/waf_elk/logstash/pipeline/logstash.conf
@@ -145,10 +145,10 @@ filter {
         event.set("[attack_classification][severity]", severity)
         event.set("[attack_classification][honeytrap_rule_id]", rule_id)
         
-        # Check if the triggered rule is a custom honeytrap rule.
-        # This matches the current 6-digit PoC rules (999xxx) AND the future GSoC 7-digit plugin range (9500000-9999999).
+        # check if the triggered rule belongs to the honeytrap plugin.
+        # all honeytrap rules are in the official 9500000-9999999 range.
         rule_id_int = rule_id.to_i
-        honeytrap_triggered = (rule_id_int >= 999000 && rule_id_int <= 999999) || (rule_id_int >= 9500000 && rule_id_int <= 9999999)
+        honeytrap_triggered = (rule_id_int >= 9500000 && rule_id_int <= 9999999)
         event.set("[attack_classification][honeytrap_triggered]", honeytrap_triggered)
         
         event.set("[attack_classification][type]", attack_type)
@@ -163,6 +163,13 @@ filter {
       event.set("[response][honeytoken_triggered]", cookie.include?("Admin="))
     '
   }
+  
+  mutate {
+    add_field => {
+      "[feed_metadata][export_timestamp]" => "%{@timestamp}"
+      "[feed_metadata][batch_id]" => "pending_export"
+    }
+  }
 
   } else if [modsec][event_type] == "persona_rotation" {
     mutate {
@@ -175,7 +182,6 @@ filter {
   }
 
   mutate {
-    add_field => { "[feed_metadata][export_timestamp]" => "%{@timestamp}" }
     remove_field => ["modsec"]
   }
 }

--- a/honeytraps/waf_modsec/Dockerfile
+++ b/honeytraps/waf_modsec/Dockerfile
@@ -3,6 +3,10 @@ FROM owasp/modsecurity-crs:${CRS_VERSION}
 USER root
 RUN apt update && apt install -y wget nano curl
 COPY include.conf /etc/modsecurity.d/
+# copy honeytrap plugin files into the crs plugin directory so include.conf picks them up
+COPY plugins/ /etc/modsecurity.d/owasp-crs/plugins/
+# install python3 and the watchdog library for rule_watcher.py
+RUN apt install -y python3 python3-pip && pip3 install watchdog --break-system-packages
 ARG FILEBEAT_VERSION=8.9.0
 ARG TARGETARCH=amd64
 RUN wget -q https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${FILEBEAT_VERSION}-${TARGETARCH}.deb \
@@ -11,10 +15,12 @@ RUN wget -q https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${FIL
 COPY filebeat.yml /etc/filebeat/filebeat.yml
 RUN chmod go-w /etc/filebeat/filebeat.yml
 COPY modsec_entry.sh /
+COPY rule_watcher.py /app/rule_watcher.py
 COPY httpd.conf /usr/local/apache2/conf/httpd.conf
 COPY robots.txt /usr/local/apache2/htdocs/
 COPY index.html /usr/local/apache2/htdocs/
 COPY login.html /usr/local/apache2/htdocs/
+COPY login.php.bak /usr/local/apache2/htdocs/
 COPY modsecurity-extension.conf /app/modsecurity-extension.conf
 RUN cat /app/modsecurity-extension.conf >> /etc/modsecurity.d/modsecurity.conf
 RUN touch /var/log/modsec_audit.log && chmod 666 /var/log/modsec_audit.log

--- a/honeytraps/waf_modsec/login.php.bak
+++ b/honeytraps/waf_modsec/login.php.bak
@@ -1,0 +1,13 @@
+<?php
+// DB credentials backup - DO NOT DEPLOY TO PROD
+$db_host = "localhost";
+$db_user = "admin";
+$db_pass = "admin123";
+$db_name = "honeypot_db";
+
+$conn = mysqli_connect($db_host, $db_user, $db_pass, $db_name);
+if (!$conn) {
+    die("Connection failed: " . mysqli_connect_error());
+}
+?>
+<!-- Rest of the login form logic would go here -->

--- a/honeytraps/waf_modsec/modsec_entry.sh
+++ b/honeytraps/waf_modsec/modsec_entry.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+mkdir -p /tmp/modsecurity/data
+chown -R daemon:daemon /tmp/modsecurity/data
 apachectl
+python3 /app/rule_watcher.py &
 filebeat -e -c /etc/filebeat/filebeat.yml -d "publish"

--- a/honeytraps/waf_modsec/modsecurity-extension.conf
+++ b/honeytraps/waf_modsec/modsecurity-extension.conf
@@ -1,84 +1,11 @@
-## APPENDED TO THE END OF 
-# /etc/modsecurity.d/modsecurity.conf
-
+## appended to /etc/modsecurity.d/modsecurity.conf at build time
+## via: RUN cat /app/modsecurity-extension.conf >> /etc/modsecurity.d/modsecurity.conf
+##
+## this file contains only the core modsecurity settings for the honeytraps stack.
+## all WAF honeytrap detection rules have been migrated to the CRS v4 plugin
+## structure under plugins/honeytrap-*.conf (loaded via include.conf).
 
 SecAuditLogFormat JSON
 SecAuditLog /var/log/modsec_audit.log
 SecContentInjection On
 SecStreamOutBodyInspection On
-
-##HONEYTRAP-1
-
-# # Generate Alerts for all requests that we receive and # set a variable in the IP Collection to mark the client # as malicious. # 
-SecRule SERVER_PORT "^(8000|8080|8888)$" \
-     "id:'999004',phase:2,t:none,log,block,msg:'HoneyTrap Alert: Traffic Received on Fake Port.',setvar:ip.malicious_client=1"
-##HONEYTRAP-2
-#Fake robots.txt file
-
-SecRule REQUEST_FILENAME "@streq /robots.txt" \
-"id:'999005',phase:4,t:none,nolog,pass,append:'Disallow: /db_backup.%{time_epoch}/'"
-
-#Identifying the malicious client
-
-SecRule REQUEST_FILENAME "^/db_backup.\d{10}" "id:'999006',phase:1,t:none,log,block,msg:'HoneyTrap Alert: Disallowed robots.txt Entry Accessed.',logdata:'%{matched_var}',setvar:ip.malicious_client=1"
-
-#Setting the Fake Authentication
-SecRule REQUEST_FILENAME "^/db_backup.\d{10}" "id:'999011',phase:3,t:none,log,deny,status:401,msg:'HoneyTrapAlert:Disallowed robots.txt Entry Accessed.',logdata:'%{matched_var}',setvar:ip.malicious_client=1, setenv:basic_auth=1" 
-Header always set WWW-Authenticate "Basic realm=\"Admin\"" env=basic_auth
-
-#For Decoding the Password given by the Hacker 
-#we use following ruleset to extract and decode thecredentials.
-
-SecRule REQUEST_FILENAME "^/db_backup.\d{10}" "chain,id:'999012',phase:1,t:none,log,msg:'HoneyTrap Alert: Authentication Attempt to Fake Resource.',logdata:'Credentials used: %{matched_var}'"  
-
-SecRule REQUEST_HEADERS:Authorization "^Basic (.*)" "chain,capture"    
-
-SecRule TX:1 ".*" "t:base64Decode"
-
-##HONEYTRAP-3
-
-##We will add some fake HTML comments 
-##With this data, an attacker may be able to better plan and execute attacks against your web application
-
-SecRule REQUEST_FILENAME "@streq /login.html" "chain,id:'999007',phase:4,t:none,nolog,pass,setvar:'tx.form_comment_honeytrap=<form action=\"login.html\" method=\"post\">'"
-
-SecRule STREAM_OUTPUT_BODY "@rsub s/%{tx.form_comment_honeytrap}/<!-- DEBUG - the source code for the old login page is login.php.bak -->%{tx.form_comment_honeytrap}/d"
-
-SecRule REQUEST_FILENAME "@streq /login.php.bak" "id:'999008',phase:1,t:none,log,block,msg:'HoneyTrap Alert: Fake HTML Comment Data Used.',setvar:ip.malicious_client=1"
-
-##HONEYTRAP-4 
-
-
-
-# Adding Fake Hidden Form Fields
-#
-# Add a fake "debug" hidden parameter to forms.
-#
-# Here are some examples of parameter names/values that could be
-# used:
-#
-# - debug=false
-# - debug=0
-# - role=user
-# - role=1
-# - admin=false
-# - admin=0
-#
-# Make sure that your settings here match the detection rules above.
-#
-SecRule STREAM_OUTPUT_BODY "@rsub s/<\/form>/<input type=\"hidden\" name=\"debug\" value=\"false\"><\/form>/" "id:'999009',phase:4,t:none,nolog,pass"
-
-#Detecting the client if the rule is triggered
-
-SecRule ARGS:debug "!@streq false" "id:'999010',phase:2,t:none,log,block,msg:'HoneyTrap Alert: Fake HIDDEN Form Data Manipulated.',setvar:ip.malicious_client=1"
-
-##HONEYTRAP-5
-##Adding Fake Cookies
-
-SecRule RESPONSE_HEADERS:Set-Cookie "^(.*?)=" "id:'999013',phase:3,t:none,nolog,pass,capture,setenv:honeytrap_cookie_name=%{tx.1}-user_role"
-
-Header always set Set-Cookie "%{HONEYTRAP_COOKIE_NAME}e=Admin:0"
-
-SecRule REQUEST_HEADERS:Cookie "@contains %{global.honeytrap_cookie_name}" "chain,id:'999014',phase:1,t:none,log,block,msg:'HoneyTrap Alert: Fake Cookie Data Manipulation'"
-
-SecRule REQUEST_HEADERS:Cookie "!@contains =Admin:0" "setvar:ip.malicious_client=1"

--- a/honeytraps/waf_modsec/plugins/honeytrap-after.conf
+++ b/honeytraps/waf_modsec/plugins/honeytrap-after.conf
@@ -1,0 +1,64 @@
+# honeytrap-after.conf
+# Rules that fire after the core CRS scoring phase.
+# These handle response-level deception: injecting fake cookies
+# and then detecting if a client tampers with them.
+# All IDs are in the 9500200-9500299 range (after-rules sub-range).
+
+# -----------------------------------------------------------------------
+# HONEYTRAP 6: Fake cookie injection and tampering detection
+# We set a fake Admin cookie on every response. If a client modifies
+# the value and sends it back, they were clearly probing for privilege
+# escalation via cookie manipulation.
+# -----------------------------------------------------------------------
+
+# Step 1: capture the existing Set-Cookie name from the response
+# so we can build a unique companion cookie name for the honeytoken.
+SecRule RESPONSE_HEADERS:Set-Cookie "@rx ^(.*?)=" \
+    "id:9500200,\
+    phase:3,\
+    pass,\
+    nolog,\
+    capture,\
+    setenv:honeytrap_cookie_name=%{tx.1}-user_role"
+
+# Step 2: inject our fake Admin cookie alongside the real one.
+Header always set Set-Cookie "%{HONEYTRAP_COOKIE_NAME}e=Admin:0"
+
+# Step 3: on subsequent requests, detect if the client tampered with
+# the Admin value. Any value other than the one we set is a hit.
+SecRule REQUEST_HEADERS:Cookie "@contains %{global.honeytrap_cookie_name}" \
+    "id:9500201,\
+    phase:1,\
+    chain,\
+    deny,status:403,\
+    log,\
+    msg:'Honeytrap Alert: Fake cookie value tampered',\
+    tag:'honeytrap',\
+    tag:'MITRE/T1565',\
+    setvar:'ip.malicious_client=1'"
+    SecRule REQUEST_HEADERS:Cookie "!@contains =Admin:0" \
+        "nolog"
+
+# -----------------------------------------------------------------------
+# HONEYTRAP 5: Rapid probing / scanner detection
+# A client making more than 20 requests in a 10-second window is almost
+# certainly running automated tooling. We block and flag them.
+# -----------------------------------------------------------------------
+SecRule REQUEST_HEADERS:User-Agent "@rx ." \
+    "id:9500109,\
+    phase:1,\
+    pass,\
+    nolog,\
+    initcol:ip=%{remote_addr},\
+    setvar:'ip.request_count=+1',\
+    expirevar:'ip.request_count=10'"
+
+SecRule IP:REQUEST_COUNT "@gt 20" \
+    "id:9500110,\
+    phase:1,\
+    deny,status:403,\
+    log,\
+    msg:'Honeytrap Alert: Rapid probing detected, more than 20 requests in 10 seconds',\
+    tag:'honeytrap',\
+    tag:'MITRE/T1595',\
+    setvar:'ip.malicious_client=1'"

--- a/honeytraps/waf_modsec/plugins/honeytrap-before.conf
+++ b/honeytraps/waf_modsec/plugins/honeytrap-before.conf
@@ -1,0 +1,137 @@
+# honeytrap-before.conf
+# Rules that fire before the core CRS scoring phase.
+# These cover active deception lures: fake high-value endpoints,
+# scanner fingerprinting, rapid probing detection, and credential canaries.
+# All IDs are in the 9500100-9500199 range (before-rules sub-range).
+
+# -----------------------------------------------------------------------
+# HONEYTRAP 1: Fake port traffic detection
+# Traffic arriving on the fake high-interaction ports (8000, 8888)
+# marks the client as malicious. Legitimate services don't live here.
+# -----------------------------------------------------------------------
+SecRule SERVER_PORT "@rx ^(8000|8888)$" \
+    "id:9500100,\
+    phase:2,\
+    deny,status:403,\
+    log,\
+    msg:'Honeytrap Alert: Traffic on fake high-interaction port',\
+    tag:'honeytrap',\
+    tag:'MITRE/T1046',\
+    setvar:'ip.malicious_client=1',\
+    setvar:'ip.fake_port_hits=+1'"
+
+# -----------------------------------------------------------------------
+# HONEYTRAP 2: Fake robots.txt disallow entry injection
+# We inject a fake disallowed path into robots.txt responses at phase 4.
+# When a scanner or attacker requests that path, we know they parsed
+# robots.txt specifically looking for hidden resources to probe.
+# -----------------------------------------------------------------------
+SecRule REQUEST_FILENAME "@streq /robots.txt" \
+    "id:9500101,\
+    phase:4,\
+    pass,\
+    nolog,\
+    append:'Disallow: /db_backup.%{time_epoch}/'"
+
+SecRule REQUEST_FILENAME "@rx ^/db_backup\.\d{10}" \
+    "id:9500102,\
+    phase:1,\
+    pass,\
+    log,\
+    msg:'Honeytrap Alert: Fake robots.txt disallow entry accessed',\
+    tag:'honeytrap',\
+    tag:'MITRE/T1592',\
+    logdata:'%{matched_var}',\
+    setvar:'ip.malicious_client=1'"
+
+# Serve a 401 to invite credential submission on the fake resource
+SecRule REQUEST_FILENAME "@rx ^/db_backup\.\d{10}" \
+    "id:9500103,\
+    phase:3,\
+    deny,\
+    status:401,\
+    log,\
+    msg:'Honeytrap Alert: Issuing 401 challenge on fake resource',\
+    tag:'honeytrap',\
+    setvar:'ip.malicious_client=1',\
+    setenv:basic_auth=1"
+
+Header always set WWW-Authenticate "Basic realm=\"Admin\"" env=basic_auth
+
+# Capture and log any credentials submitted to the fake resource
+SecRule REQUEST_FILENAME "@rx ^/db_backup\.\d{10}" \
+    "id:9500104,\
+    phase:1,\
+    chain,\
+    log,\
+    msg:'Honeytrap Alert: Credential canary attempt on fake resource',\
+    tag:'honeytrap',\
+    tag:'MITRE/T1110',\
+    logdata:'Credentials: %{matched_var}'"
+    SecRule REQUEST_HEADERS:Authorization "@rx ^Basic (.*)" \
+        "chain,\
+        capture"
+        SecRule TX:1 "@rx .*" \
+            "t:base64Decode"
+
+# -----------------------------------------------------------------------
+# HONEYTRAP 3: Fake HTML comment lure (login.php.bak)
+# We inject a comment into login.html responses hinting at login.php.bak.
+# If a client requests that file they were clearly reading our page source.
+# -----------------------------------------------------------------------
+SecRule REQUEST_FILENAME "@streq /login.html" \
+    "id:9500105,\
+    phase:4,\
+    pass,\
+    nolog,\
+    chain,\
+    setvar:'tx.form_comment_honeytrap=<form action=\"login.html\" method=\"post\">'"
+    SecRule STREAM_OUTPUT_BODY "@rsub s/%{tx.form_comment_honeytrap}/<!-- DEBUG: old login source is login.php.bak -->%{tx.form_comment_honeytrap}/d" \
+        "nolog"
+
+SecRule REQUEST_FILENAME "@streq /login.php.bak" \
+    "id:9500106,\
+    phase:1,\
+    pass,\
+    log,\
+    msg:'Honeytrap Alert: Fake HTML comment lure accessed',\
+    tag:'honeytrap',\
+    tag:'MITRE/T1592',\
+    ctl:ruleRemoveById=920440,\
+    setvar:'ip.malicious_client=1'"
+
+# -----------------------------------------------------------------------
+# HONEYTRAP 4: Fake hidden form field (debug parameter)
+# We inject a hidden debug=false field into all form responses.
+# If a client sends debug with any value other than false, they tampered.
+# -----------------------------------------------------------------------
+SecRule STREAM_OUTPUT_BODY "@rsub s/<\/form>/<input type=\"hidden\" name=\"debug\" value=\"false\"><\/form>/" \
+    "id:9500107,\
+    phase:4,\
+    pass,\
+    nolog"
+
+SecRule ARGS:debug "!@streq false" \
+    "id:9500108,\
+    phase:2,\
+    deny,status:403,\
+    log,\
+    msg:'Honeytrap Alert: Fake hidden form field tampered',\
+    tag:'honeytrap',\
+    tag:'MITRE/T1565',\
+    setvar:'ip.malicious_client=1'"
+
+# -----------------------------------------------------------------------
+# HONEYTRAP 5: Scanner Fingerprinting
+# Detect known automated security scanners via User-Agent signatures.
+# This is a distinct mechanism from rapid probing (which tracks velocity).
+# -----------------------------------------------------------------------
+SecRule REQUEST_HEADERS:User-Agent "@rx (?i)(nikto|zmap|masscan|nmap|sqlmap|nuclei)" \
+    "id:9500111,\
+    phase:1,\
+    deny,status:403,\
+    log,\
+    msg:'Honeytrap Alert: Known scanner fingerprint detected',\
+    tag:'honeytrap',\
+    tag:'MITRE/T1595',\
+    setvar:'ip.malicious_client=1'"

--- a/honeytraps/waf_modsec/plugins/honeytrap-config.conf
+++ b/honeytraps/waf_modsec/plugins/honeytrap-config.conf
@@ -1,0 +1,18 @@
+# honeytrap-config.conf
+# CRS plugin metadata for the honeytraps plugin.
+# All rules for this plugin live in the 9500000-9599999 ID range
+# to avoid collisions with core CRS rules and any future plugins.
+#
+# Plugin structure follows the official CRS v4 plugin loading order:
+#   plugins/*-config.conf   (this file, loaded before core rules)
+#   plugins/*-before.conf   (detection rules that run before CRS scoring)
+#   rules/*.conf            (core CRS rules)
+#   plugins/*-after.conf    (enrichment rules that run after CRS scoring)
+
+SecAction \
+    "id:9500001,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'honeytrap-plugin/1.0.0',\
+    setvar:'tx.honeytrap_plugin_version=1.0.0'"

--- a/honeytraps/waf_modsec/rule_watcher.py
+++ b/honeytraps/waf_modsec/rule_watcher.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+rule_watcher.py
+
+watches the crs plugin directory for any changes to honeytrap rule files
+and triggers an apache graceful reload so new rules take effect without
+a container restart.
+
+follows the same watchdog observer pattern as preprocess-modsec-log.py
+in the legacy demo stack, applied to rule files instead of log files.
+
+if apachectl graceful fails 3 times in a row, we fall back to a full
+container restart so the honeypot is never left in a broken state.
+this matches the fallback behavior documented in the gsoc proposal.
+"""
+
+import subprocess
+import logging
+import time
+import sys
+
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+PLUGIN_DIR = "/etc/modsecurity.d/owasp-crs/plugins"
+MAX_GRACEFUL_FAILURES = 3
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s][%(levelname)s][rule_watcher] %(message)s",
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        logging.FileHandler("/var/log/rule_watcher.log"),
+    ],
+)
+log = logging.getLogger("rule_watcher")
+
+
+class PluginRuleHandler(FileSystemEventHandler):
+    """
+    fires on any create, modify, or delete event under the plugin directory.
+    only acts on .conf files to avoid reacting to temp editor swap files.
+    """
+
+    def __init__(self):
+        self._graceful_failures = 0
+
+    def on_modified(self, event):
+        if event.is_directory:
+            return
+        if event.src_path.endswith(".conf"):
+            log.info("rule file changed: %s", event.src_path)
+            self._reload()
+
+    def on_created(self, event):
+        if event.is_directory:
+            return
+        if event.src_path.endswith(".conf"):
+            log.info("new rule file detected: %s", event.src_path)
+            self._reload()
+
+    def on_deleted(self, event):
+        if event.is_directory:
+            return
+        if event.src_path.endswith(".conf"):
+            log.info("rule file removed: %s", event.src_path)
+            self._reload()
+
+    def on_moved(self, event):
+        if event.is_directory:
+            return
+        if hasattr(event, 'dest_path') and event.dest_path.endswith(".conf"):
+            log.info("rule file moved/renamed: %s -> %s", event.src_path, event.dest_path)
+            self._reload()
+
+    def _reload(self):
+        """
+        attempts an apache graceful reload. if it fails 3 times consecutively
+        we give up on graceful and force a full apache restart to guarantee
+        the honeypot stays in a consistent state.
+        """
+        log.info("triggering apachectl graceful reload")
+        result = subprocess.run(
+            ["apachectl", "graceful"],
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode == 0:
+            log.info("graceful reload succeeded")
+            self._graceful_failures = 0
+        else:
+            self._graceful_failures += 1
+            log.warning(
+                "graceful reload failed (attempt %d/%d): %s",
+                self._graceful_failures,
+                MAX_GRACEFUL_FAILURES,
+                result.stderr.strip(),
+            )
+
+            if self._graceful_failures >= MAX_GRACEFUL_FAILURES:
+                log.error(
+                    "graceful reload failed %d times in a row, falling back to full restart",
+                    MAX_GRACEFUL_FAILURES,
+                )
+                self._graceful_failures = 0
+                restart = subprocess.run(
+                    ["apachectl", "restart"],
+                    capture_output=True,
+                    text=True,
+                )
+                if restart.returncode == 0:
+                    log.info("full restart succeeded")
+                else:
+                    log.error("full restart also failed: %s", restart.stderr.strip())
+
+
+if __name__ == "__main__":
+    log.info("rule_watcher starting, watching %s", PLUGIN_DIR)
+
+    event_handler = PluginRuleHandler()
+    observer = Observer()
+    observer.schedule(event_handler, PLUGIN_DIR, recursive=False)
+    observer.start()
+
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        log.info("shutting down")
+        observer.stop()
+
+    observer.join()

--- a/mds_elk/waf_elk/filebeat_logstash.conf
+++ b/mds_elk/waf_elk/filebeat_logstash.conf
@@ -197,6 +197,15 @@ filter {
     '
   }
 
+  mutate {
+    add_field => { 
+      "[feed_metadata][export_timestamp]" => "%{@timestamp}" 
+      # placeholder because actual uuid batch ids will be dynamically generated
+      # by the python exporter daemon when batching events for misp/stix in deliverable 7
+      "[feed_metadata][batch_id]" => "pending_export"
+    }
+  }
+
   } else if [modsec][event_type] == "persona_rotation" {
     # It's a persona rotation event pre-formatted by the watchdog script
     mutate {
@@ -209,12 +218,6 @@ filter {
   }
 
   mutate {
-    add_field => { 
-      "[feed_metadata][export_timestamp]" => "%{@timestamp}" 
-      # placeholder because actual uuid batch ids will be dynamically generated
-      # by the python exporter daemon when batching events for misp/stix in deliverable 7
-      "[feed_metadata][batch_id]" => "pending_export"
-    }
     remove_field => ["modsec"]
   }
 }

--- a/mds_elk/waf_modsec/modsecurity.conf
+++ b/mds_elk/waf_modsec/modsecurity.conf
@@ -225,7 +225,3 @@ SecUnicodeMapFile unicode.mapping 20127
 # version, Anonymous unique id for host.
 SecStatusEngine On
 
-# # Generate Alerts for all requests that we receive and # set a variable in the IP Collection to mark the client # as malicious. # 
-# # Generate Alerts for all requests that we receive and # set a variable in the IP Collection to mark the client # as malicious. # 
-SecRule SERVER_PORT "^(8000|8080|8888)$" \
-     "id:'999004',phase:2,t:none,log,block,msg:'HoneyTrap Alert: Traffic Received on Fake Port.',setvar:ip.malicious_client=1"

--- a/mlogc_elk/mlogc/modsecurity.conf
+++ b/mlogc_elk/mlogc/modsecurity.conf
@@ -224,7 +224,3 @@ SecUnicodeMapFile unicode.mapping 20127
 # version, Anonymous unique id for host.
 SecStatusEngine On
 
-# # Generate Alerts for all requests that we receive and # set a variable in the IP Collection to mark the client # as malicious. # 
-# # Generate Alerts for all requests that we receive and # set a variable in the IP Collection to mark the client # as malicious. # 
-SecRule SERVER_PORT "^(8000|8080|8888)$" \
-     "id:'999004',phase:2,t:none,log,block,msg:'HoneyTrap Alert: Traffic Received on Fake Port.',setvar:ip.malicious_client=1"


### PR DESCRIPTION
Hey @adrianwinckles,

This PR introduces the core active deception capabilities for the WAF, adds a live rule reloading mechanism, and refactors the Logstash telemetry pipeline to strictly enforce the new v1.1 schema. 

Here is a detailed breakdown of exactly what I built and fixed in this branch:

### Active Deception Plugins
I built a dedicated honeypot plugin architecture using `honeytrap-before.conf`, `honeytrap-after.conf`, and `honeytrap-config.conf`. I migrated the old inline honeytraps into this plugin structure and mapped all custom rules to the 9500100 to 9500201 range to avoid collisions with core CRS rules.

*   **Scanner Fingerprinting:** I added Rule 9500111 to instantly catch and drop traffic from known automated scanners based on User-Agent regex matching (Nikto, Nmap, Masscan, Zmap, Sqlmap, Nuclei) on the very first request.
*   **Rapid Probing Detection:** I configured ModSecurity DBM collections to track IP request velocity, triggering an expirevar lockout if a client makes 20 requests within a 10 second window. I also fixed a critical runtime bug where Apache lacked permissions to write to the tracking database by updating `modsec_entry.sh` to create and `chown daemon:daemon` the `/tmp/modsecurity/data` directory.
*   **Credential Canaries:** I set up the WAF to inject fake Disallow paths into `/robots.txt` pointing to dynamically generated `/db_backup` endpoints. If an attacker accesses them, the WAF issues a 401 Unauthorized challenge and logs any base64 Basic Auth credentials they try to brute force.
*   **Decoy File Traps:** I injected hidden HTML comments into the page source pointing to a fake `/login.php.bak` file that I physically created with dummy PHP and MySQL credentials. I also added a specific rule exception (`ctl:ruleRemoveById=920440`) for that `.bak` file so the core CRS rules do not blindly block attackers from reaching our bait.
*   **Tamper Detection:** The WAF now injects a fake `Admin:0` cookie and a hidden `debug=false` form field into outgoing responses. I wrote rules that instantly flag any client that tries to submit modified versions of these values.
*   **Fake Ports:** I added rules to trap traffic arriving on fake high interaction ports (8000 and 8888). I explicitly excluded port 8080 from this trap because Apache listens on 8080 internally within our Docker network, which would have caused us to block all of our own legitimate traffic.

### Live Rule Reloading
I engineered `rule_watcher.py`, a Python watchdog daemon that monitors the ModSecurity plugin directory. When it detects file modifications, it automatically issues an `apachectl graceful` command. This allows us to tweak and deploy new honeypot rules live in production without dropping the WAF container or active TCP connections.

### Logstash Schema Normalization
I updated `mds_elk` and `mlogc_elk` to enable `SecAuditLogFormat JSON` globally. As outlined in the proposal's risk mitigation plan, `mlogc_elk` is deliberately being kept active in parallel logging mode during this transition to ensure 100% of logs parse safely before we fully deprecate the legacy stack. I rewrote the Logstash parsing logic (`logstash.conf` and `filebeat_logstash.conf`) to strictly output the new v1.1 JSON schema.

*   **Metadata Injection:** Logstash now parses the raw JSON and automatically injects the `feed_metadata` block with `batch_id` set to `pending_export`, preparing the telemetry for downstream MISP and STIX exporters.
*   **System Event Isolation:** I restructured the pipeline to safely route `persona_rotation` system events away from actual attack events. 
*   **Data Leakage Fix:** The legacy `previous_persona` field was leaking into attack logs where it did not belong. I fixed this by dropping it entirely from the attack telemetry, but I explicitly preserved it inside the `persona_rotation` schema envelope to maintain our historical audit tracking.
*   **Documentation:** I updated `SCHEMA_MIGRATION.md` to document the new `feed_metadata` block and the `previous_persona` changes for the v1.1 schema.

Please let me know if everything looks good, or if you'd recommend any changes.