### PR TITLE
feat: add 4 vulnerable application personas for the chameleon engine

### DIFF
--- a/honeytraps/personas/apache-2.2-php5/Dockerfile
+++ b/honeytraps/personas/apache-2.2-php5/Dockerfile
@@ -1,0 +1,17 @@
+FROM httpd:2.4
+
+COPY html/ /usr/local/apache2/htdocs/
+
+# fake cgi binaries for the /cgi-bin/php and /cgi-bin/php5 probe paths (CVE-2012-1823)
+COPY cgi-bin/php /usr/local/apache2/cgi-bin/php
+COPY cgi-bin/php5 /usr/local/apache2/cgi-bin/php5
+RUN chmod +x /usr/local/apache2/cgi-bin/php /usr/local/apache2/cgi-bin/php5
+
+# Server header override is handled at the WAF layer via SecServerSignature.
+COPY vhost.conf /usr/local/apache2/conf/extra/persona-apache22.conf
+
+RUN echo "LoadModule headers_module modules/mod_headers.so" >> /usr/local/apache2/conf/httpd.conf \
+ && echo "LoadModule cgi_module modules/mod_cgi.so" >> /usr/local/apache2/conf/httpd.conf \
+ && echo "Include conf/extra/persona-apache22.conf" >> /usr/local/apache2/conf/httpd.conf
+
+EXPOSE 80

--- a/honeytraps/personas/apache-2.2-php5/cgi-bin/php
+++ b/honeytraps/personas/apache-2.2-php5/cgi-bin/php
@@ -1,0 +1,8 @@
+#!/bin/sh
+# fake php cgi wrapper
+# returns a realistic php-cgi header response so scanners think
+# they found a real CVE-2012-1823 target
+echo "Content-Type: text/html"
+echo "X-Powered-By: PHP/5.4.45"
+echo ""
+echo "<html><body>PHP CGI</body></html>"

--- a/honeytraps/personas/apache-2.2-php5/cgi-bin/php5
+++ b/honeytraps/personas/apache-2.2-php5/cgi-bin/php5
@@ -1,0 +1,6 @@
+#!/bin/sh
+# fake php5 cgi wrapper (same as /cgi-bin/php, scanners check both paths)
+echo "Content-Type: text/html"
+echo "X-Powered-By: PHP/5.4.45"
+echo ""
+echo "<html><body>PHP CGI</body></html>"

--- a/honeytraps/personas/apache-2.2-php5/html/index.html
+++ b/honeytraps/personas/apache-2.2-php5/html/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><title>Apache 2.2 Test Page</title></head>
+<body>
+<h1>It works!</h1>
+<p>This is the default web page for this server.</p>
+<p>The web server software is running but no content has been added, yet.</p>
+</body>
+</html>

--- a/honeytraps/personas/apache-2.2-php5/persona.json
+++ b/honeytraps/personas/apache-2.2-php5/persona.json
@@ -1,0 +1,13 @@
+{
+  "name": "apache-2.2-php5",
+  "version": "Apache/2.2.31 PHP/5.4.45",
+  "cve": ["CVE-2012-1823"],
+  "profile": "general",
+  "description": "Apache 2.2 with PHP-CGI argument injection. CVE-2012-1823 allows an attacker to pass arguments to the PHP interpreter via the query string when PHP is running in CGI mode.",
+  "shodan_fingerprint": "Apache/2.2",
+  "exposed_endpoints": [
+    "/cgi-bin/php",
+    "/cgi-bin/php5",
+    "/index.php"
+  ]
+}

--- a/honeytraps/personas/apache-2.2-php5/vhost.conf
+++ b/honeytraps/personas/apache-2.2-php5/vhost.conf
@@ -1,0 +1,17 @@
+# apache-2.2-php5/vhost.conf
+#
+# Extra Apache directives for the apache-2.2-php5 persona.
+# fake the server banner and PHP version to match what CVE-2012-1823 scanners expect.
+ServerTokens Prod
+Header always unset Server
+Header always set Server "Apache/2.2.31 (Unix) PHP/5.4.45"
+Header always set X-Powered-By "PHP/5.4.45"
+
+# ScriptAlias needed, otherwise Apache serves the cgi scripts as plain text.
+ScriptAlias /cgi-bin/ /usr/local/apache2/cgi-bin/
+
+<Directory "/usr/local/apache2/cgi-bin">
+    AllowOverride None
+    Options +ExecCGI
+    Require all granted
+</Directory>

--- a/honeytraps/personas/iis-7.5-fastcgi/Dockerfile
+++ b/honeytraps/personas/iis-7.5-fastcgi/Dockerfile
@@ -1,0 +1,11 @@
+FROM httpd:2.4
+
+COPY html/ /usr/local/apache2/htdocs/
+
+# ASP.NET headers only, Server header is handled at the WAF layer.
+COPY vhost.conf /usr/local/apache2/conf/extra/persona-iis75.conf
+
+RUN echo "LoadModule headers_module modules/mod_headers.so" >> /usr/local/apache2/conf/httpd.conf \
+ && echo "Include conf/extra/persona-iis75.conf" >> /usr/local/apache2/conf/httpd.conf
+
+EXPOSE 80

--- a/honeytraps/personas/iis-7.5-fastcgi/html/default.aspx
+++ b/honeytraps/personas/iis-7.5-fastcgi/html/default.aspx
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>Object moved</title></head>
+<body>
+<h2>Object moved to <a href="/iisstart.htm">here</a>.</h2>
+</body>
+</html>

--- a/honeytraps/personas/iis-7.5-fastcgi/html/iisstart.htm
+++ b/honeytraps/personas/iis-7.5-fastcgi/html/iisstart.htm
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>IIS7</title>
+</head>
+<body>
+<div id="container">
+    <a href="http://go.microsoft.com/fwlink/?linkid=66138&amp;clcid=0x409">
+        <img src="/welcome.png" alt="IIS7" width="571" height="411" />
+    </a>
+</div>
+</body>
+</html>

--- a/honeytraps/personas/iis-7.5-fastcgi/persona.json
+++ b/honeytraps/personas/iis-7.5-fastcgi/persona.json
@@ -1,0 +1,13 @@
+{
+  "name": "iis-7.5-fastcgi",
+  "version": "Microsoft-IIS/7.5",
+  "cve": ["CVE-2010-2730"],
+  "profile": "financial",
+  "description": "IIS 7.5 with FastCGI extension buffer overflow. CVE-2010-2730 allows RCE via an overly long request header processed by the FastCGI extension.",
+  "shodan_fingerprint": "Microsoft-IIS/7.5",
+  "exposed_endpoints": [
+    "/",
+    "/default.aspx",
+    "/iisstart.htm"
+  ]
+}

--- a/honeytraps/personas/iis-7.5-fastcgi/vhost.conf
+++ b/honeytraps/personas/iis-7.5-fastcgi/vhost.conf
@@ -1,0 +1,15 @@
+# iis-7.5-fastcgi/vhost.conf
+#
+# Extra Apache directives for the iis-7.5-fastcgi persona.
+# fake the server banner so Shodan fingerprints this as IIS 7.5.
+ServerTokens Prod
+Header always unset Server
+Header always set Server "Microsoft-IIS/7.5"
+Header always set X-Powered-By "ASP.NET"
+Header always set X-AspNet-Version "4.0.30319"
+
+<Directory "/usr/local/apache2/htdocs">
+    AllowOverride All
+    Options -Indexes
+    Require all granted
+</Directory>

--- a/honeytraps/personas/phpmyadmin-4.8.1/Dockerfile
+++ b/honeytraps/personas/phpmyadmin-4.8.1/Dockerfile
@@ -1,0 +1,10 @@
+FROM httpd:2.4
+
+COPY html/ /usr/local/apache2/htdocs/
+
+COPY vhost.conf /usr/local/apache2/conf/extra/persona-phpmyadmin.conf
+
+RUN echo "LoadModule headers_module modules/mod_headers.so" >> /usr/local/apache2/conf/httpd.conf \
+ && echo "Include conf/extra/persona-phpmyadmin.conf" >> /usr/local/apache2/conf/httpd.conf
+
+EXPOSE 80

--- a/honeytraps/personas/phpmyadmin-4.8.1/html/phpmyadmin/index.php
+++ b/honeytraps/personas/phpmyadmin-4.8.1/html/phpmyadmin/index.php
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>phpMyAdmin</title>
+<meta charset="utf-8">
+<meta name="generator" content="phpMyAdmin 4.8.1" />
+</head>
+<body>
+<div id="login_form">
+    <form method="post" action="index.php" name="login_form">
+        <fieldset>
+            <legend>Log in</legend>
+
+            <div class="item">
+                <label for="input_username">Username:</label>
+                <input type="text" name="pma_username" id="input_username" value="" size="24" class="textfield" />
+            </div>
+
+            <div class="item">
+                <label for="input_password">Password:</label>
+                <input type="password" name="pma_password" id="input_password" value="" size="24" class="textfield" autocomplete="off" />
+            </div>
+
+            <!-- AllowArbitraryServer is enabled on this instance -->
+            <div class="item">
+                <label for="input_serverchoice">Server Choice:</label>
+                <input type="text" name="pma_serverchoice" id="input_serverchoice" value="1" size="24" class="textfield" />
+            </div>
+        </fieldset>
+
+        <input type="hidden" name="server" value="1" />
+        <input type="hidden" name="target" value="index.php" />
+        <input type="hidden" name="token" value="a1b2c3d4e5f6" />
+
+        <input value="Go" type="submit" id="input_go" />
+    </form>
+</div>
+
+<div id="footer_versions">
+    <span class="version">
+        phpMyAdmin 4.8.1
+    </span>
+</div>
+</body>
+</html>

--- a/honeytraps/personas/phpmyadmin-4.8.1/persona.json
+++ b/honeytraps/personas/phpmyadmin-4.8.1/persona.json
@@ -1,0 +1,14 @@
+{
+  "name": "phpmyadmin-4.8.1",
+  "version": "4.8.1",
+  "cve": ["CVE-2018-12613"],
+  "profile": "general",
+  "description": "phpMyAdmin 4.8.1 with LFI via the file parameter, unauthenticated when AllowArbitraryServer is enabled",
+  "shodan_fingerprint": "phpMyAdmin",
+  "exposed_endpoints": [
+    "/phpmyadmin/",
+    "/phpmyadmin/index.php",
+    "/phpmyadmin/config.inc.php",
+    "/pma/"
+  ]
+}

--- a/honeytraps/personas/phpmyadmin-4.8.1/vhost.conf
+++ b/honeytraps/personas/phpmyadmin-4.8.1/vhost.conf
@@ -1,0 +1,15 @@
+# phpmyadmin-4.8.1/vhost.conf
+#
+# Extra Apache directives for the phpmyadmin-4.8.1 persona.
+# fake the PHP version header, expose /phpmyadmin/ and the /pma/ alias.
+
+Header always set X-Powered-By "PHP/5.6.40"
+
+Alias /phpmyadmin /usr/local/apache2/htdocs/phpmyadmin
+Alias /pma /usr/local/apache2/htdocs/phpmyadmin
+
+<Directory "/usr/local/apache2/htdocs/phpmyadmin">
+    AllowOverride All
+    Options -Indexes
+    Require all granted
+</Directory>

--- a/honeytraps/personas/wordpress-5.0/Dockerfile
+++ b/honeytraps/personas/wordpress-5.0/Dockerfile
@@ -1,0 +1,12 @@
+FROM httpd:2.4
+
+# fake WP file tree - this is what scanners see when they probe the endpoints.
+COPY html/ /usr/local/apache2/htdocs/
+
+# load mod_headers and include our persona config.
+COPY vhost.conf /usr/local/apache2/conf/extra/persona-wordpress.conf
+
+RUN echo "LoadModule headers_module modules/mod_headers.so" >> /usr/local/apache2/conf/httpd.conf \
+ && echo "Include conf/extra/persona-wordpress.conf" >> /usr/local/apache2/conf/httpd.conf
+
+EXPOSE 80

--- a/honeytraps/personas/wordpress-5.0/html/readme.html
+++ b/honeytraps/personas/wordpress-5.0/html/readme.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="generator" content="WordPress 5.0.3" />
+<title>WordPress &rsaquo; Readme</title>
+</head>
+<body>
+<h1 id="logo"><a href="https://wordpress.org"><img alt="WordPress" src="/wp-includes/images/wordpress-logo.png" /></a></h1>
+<p class="aligncenter">Semantic Personal Publishing Platform</p>
+
+<h2>First Things First</h2>
+<p>Welcome. WordPress is a very special project to me. Every developer and contributor adds something unique to the mix, and together we create something beautiful that I&#8217;m proud to be a part of. Thousands of hours have gone into WordPress, and we&#8217;re dedicated to making it better every day. Thank you for making it part of your world.</p>
+<p>&#8212; Matt Mullenweg</p>
+
+<h2>Installation: Famous 5-Minute Install</h2>
+
+<h2>Version 5.0.3</h2>
+<p>See: <a href="https://wordpress.org/news/2019/01/wordpress-5-0-3-maintenance-release/">WordPress 5.0.3 Maintenance Release</a></p>
+</body>
+</html>

--- a/honeytraps/personas/wordpress-5.0/html/wp-login.php
+++ b/honeytraps/personas/wordpress-5.0/html/wp-login.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="generator" content="WordPress 5.0.3" />
+<title>Log In &lsaquo; Honeypot Site &mdash; WordPress</title>
+<link rel="stylesheet" href="/wp-includes/css/buttons.min.css" type="text/css" />
+</head>
+<body class="login login-action-login wp-core-ui">
+<div id="login">
+    <h1><a href="https://wordpress.org/">WordPress</a></h1>
+    <form name="loginform" id="loginform" action="/wp-login.php" method="post">
+        <p>
+            <label for="user_login">Username or Email Address</label>
+            <input type="text" name="log" id="user_login" class="input" value="" size="20" autocapitalize="off" />
+        </p>
+        <p>
+            <label for="user_pass">Password</label>
+            <input type="password" name="pwd" id="user_pass" class="input" value="" size="20" />
+        </p>
+        <p class="forgetmenot"><input name="rememberme" type="checkbox" id="rememberme" value="forever" /> <label for="rememberme">Remember Me</label></p>
+        <p class="submit">
+            <input type="submit" name="wp-submit" id="wp-submit" class="button button-primary button-large" value="Log In" />
+            <input type="hidden" name="redirect_to" value="/wp-admin/" />
+            <input type="hidden" name="testcookie" value="1" />
+        </p>
+    </form>
+    <p id="nav">
+        <a href="/wp-login.php?action=lostpassword">Lost your password?</a>
+    </p>
+</div>
+</body>
+</html>

--- a/honeytraps/personas/wordpress-5.0/html/xmlrpc.php
+++ b/honeytraps/personas/wordpress-5.0/html/xmlrpc.php
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<methodResponse>
+  <params>
+    <param>
+      <value>
+        <array>
+          <data>
+            <value><string>system.multicall</string></value>
+            <value><string>system.listMethods</string></value>
+            <value><string>system.getCapabilities</string></value>
+            <value><string>wp.getUsersBlogs</string></value>
+            <value><string>wp.getPost</string></value>
+            <value><string>wp.newPost</string></value>
+            <value><string>wp.editPost</string></value>
+            <value><string>wp.uploadFile</string></value>
+          </data>
+        </array>
+      </value>
+    </param>
+  </params>
+</methodResponse>

--- a/honeytraps/personas/wordpress-5.0/persona.json
+++ b/honeytraps/personas/wordpress-5.0/persona.json
@@ -1,0 +1,15 @@
+{
+  "name": "wordpress-5.0",
+  "version": "5.0.3",
+  "cve": ["CVE-2019-8942", "CVE-2019-8943"],
+  "profile": "education/research",
+  "description": "WordPress 5.0.3 with chained RCE via author-level image upload and wp_crop_image() path traversal",
+  "shodan_fingerprint": "WordPress 5.0",
+  "exposed_endpoints": [
+    "/wp-login.php",
+    "/xmlrpc.php",
+    "/wp-admin/",
+    "/readme.html",
+    "/wp-content/plugins/"
+  ]
+}

--- a/honeytraps/personas/wordpress-5.0/vhost.conf
+++ b/honeytraps/personas/wordpress-5.0/vhost.conf
@@ -1,0 +1,13 @@
+# wordpress-5.0/vhost.conf
+#
+# Extra Apache directives for the wordpress-5.0 persona.
+# X-Powered-By and the meta generator tag in the HTML are what Shodan
+# picks up to fingerprint this as a WordPress 5.0 host.
+
+Header always set X-Powered-By "PHP/7.2.24"
+
+<Directory "/usr/local/apache2/htdocs">
+    AllowOverride All
+    Options -Indexes +FollowSymLinks
+    Require all granted
+</Directory>


### PR DESCRIPTION
Hey @adrianwinckles,

This PR implements the 4 vulnerable application personas that will act as the decoy backends for our honeypot. 
This sets the foundation for the Chameleon Engine which will rotate them dynamically.

Here is a breakdown of the additions:

- **WordPress 5.0 (`wordpress-5.0`):** Simulates a WordPress 5.0.3 site vulnerable to CVE-2019-8942. I added the fake `X-Powered-By` headers and exposed endpoints like `wp-login.php` and `xmlrpc.php` to bait brute force attacks.
- **phpMyAdmin 4.8.1 (`phpmyadmin-4.8.1`):** Simulates CVE-2018-12613. It returns the expected PHP headers and exposes the `/phpmyadmin/` and `/pma/` aliases.
- **Apache 2.2 with PHP 5 (`apache-2.2-php5`):** Simulates the CVE-2012-1823 CGI argument injection vulnerability. I explicitly enabled `mod_cgi` so the fake `/cgi-bin/php` scripts actually execute and return realistic CGI headers instead of serving plain text.
- **IIS 7.5 FastCGI (`iis-7.5-fastcgi`):** Simulates CVE-2010-2730. It sets the `ASP.NET` headers and serves fake IIS default pages like `iisstart.htm`.

I built each image individually and curled every single endpoint to verify the decoy HTML renders correctly and the injected headers look exactly right.

Please let me know what you think!
