### PR TITLE
fix: use multi-arch apache tag in waf_modsec Dockerfiles to fix AMD64 CI failures

### DIFF
--- a/honeytraps/waf_modsec/Dockerfile
+++ b/honeytraps/waf_modsec/Dockerfile
@@ -1,4 +1,4 @@
-ARG CRS_VERSION=4.25.0-apache-lts
+ARG CRS_VERSION=apache
 FROM owasp/modsecurity-crs:${CRS_VERSION}
 USER root
 RUN apt update && apt install -y wget nano curl

--- a/mds_elk/waf_modsec/Dockerfile
+++ b/mds_elk/waf_modsec/Dockerfile
@@ -1,4 +1,4 @@
-ARG CRS_VERSION=4.25.0-apache-lts
+ARG CRS_VERSION=apache
 FROM owasp/modsecurity-crs:${CRS_VERSION}
 USER root
 RUN apt-get update && apt-get install -y wget nano curl


### PR DESCRIPTION
Hey @adrianwinckles,

Both the nightly CRS workflow and the mds_elk docker integration tests have been failing since around Jul 4 because of a platform mismatch in the base image.

The `4.25.0-apache-lts` tag on Docker Hub only has an ARM64 manifest. The GitHub Actions ubuntu-latest runners are AMD64, so Docker immediately fails with `no match for platform in manifest` and the job dies in under 10 seconds before any layer even builds. It worked fine on ARM64 machines because the image had an ARM64 manifest, just not AMD64.

The fix is a one-line change in both `mds_elk/waf_modsec/Dockerfile` and `honeytraps/waf_modsec/Dockerfile`:

```diff
- ARG CRS_VERSION=4.25.0-apache-lts
+ ARG CRS_VERSION=apache
